### PR TITLE
Add initial UI screens and navigation scaffolding

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'ui/screens/categories_screen.dart';
+import 'ui/screens/home_screen.dart';
+import 'ui/screens/round_screen.dart';
+import 'ui/screens/summary_screen.dart';
+import 'ui/screens/stub_screen.dart';
+import 'ui/tokens.dart';
+
+void main() {
+  runApp(const DataGApp());
+}
+
+class DataGApp extends StatelessWidget {
+  const DataGApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final router = GoRouter(
+      initialLocation: '/home',
+      routes: [
+        GoRoute(
+          path: '/home',
+          builder: (context, state) => const HomeScreen(),
+        ),
+        GoRoute(
+          path: '/categories',
+          builder: (context, state) => const CategoriesScreen(),
+        ),
+        GoRoute(
+          path: '/round/:categoryId',
+          builder: (context, state) {
+            final categoryId = state.pathParameters['categoryId'] ?? 'history';
+            return RoundScreen(categoryId: categoryId);
+          },
+        ),
+        GoRoute(
+          path: '/summary',
+          builder: (context, state) => const SummaryScreen(),
+        ),
+        GoRoute(
+          path: '/stub',
+          builder: (context, state) {
+            final title = state.uri.queryParameters['title'] ?? 'Stub';
+            return StubScreen(title: title);
+          },
+        ),
+      ],
+    );
+
+    return MaterialApp.router(
+      title: 'DataG',
+      theme: ThemeData(
+        scaffoldBackgroundColor: AppColors.bgBase,
+        colorScheme: const ColorScheme.dark(
+          surface: AppColors.bgElevated,
+          background: AppColors.bgBase,
+          primary: AppColors.accentPrimary,
+          secondary: AppColors.accentSecondary,
+          error: AppColors.error,
+          onBackground: AppColors.textPrimary,
+          onSurface: AppColors.textPrimary,
+        ),
+        textTheme: const TextTheme(
+          bodyMedium: TextStyle(color: AppColors.textPrimary),
+        ),
+        useMaterial3: true,
+      ),
+      routerConfig: router,
+    );
+  }
+}

--- a/lib/ui/components/app_top_bar.dart
+++ b/lib/ui/components/app_top_bar.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+
+class AppTopBar extends StatelessWidget implements PreferredSizeWidget {
+  const AppTopBar({
+    super.key,
+    this.leading,
+    this.title,
+    this.actions,
+  });
+
+  final Widget? leading;
+  final Widget? title;
+  final List<Widget>? actions;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(64);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: preferredSize.height,
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.screenPadding),
+      alignment: Alignment.center,
+      decoration: const BoxDecoration(
+        color: AppColors.bgBase,
+        border: Border(bottom: AppBorders.muted),
+      ),
+      child: Row(
+        children: [
+          leading ?? const SizedBox(width: AppComponentSpecs.minTouchTarget),
+          const SizedBox(width: AppSpacing.grid),
+          Expanded(
+            child: DefaultTextStyle(
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textPrimary,
+              ),
+              textAlign: TextAlign.center,
+              child: title ?? const SizedBox.shrink(),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.grid),
+          if (actions != null && actions!.isNotEmpty)
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: actions!
+                  .expand(
+                    (w) => [w, const SizedBox(width: 8)],
+                  )
+                  .toList()
+                ..removeLast(),
+            )
+          else
+            const SizedBox(width: AppComponentSpecs.minTouchTarget),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/components/card_tile.dart
+++ b/lib/ui/components/card_tile.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+
+class CardTile extends StatelessWidget {
+  const CardTile({
+    super.key,
+    required this.leading,
+    required this.title,
+    this.subtitle,
+    this.onTap,
+    this.height = 72,
+  });
+
+  final Widget leading;
+  final Widget title;
+  final Widget? subtitle;
+  final VoidCallback? onTap;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.bgElevated,
+      borderRadius: AppRadius.medium,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: AppRadius.medium,
+        child: Container(
+          height: height,
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.screenPadding,
+          ),
+          alignment: Alignment.center,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              leading,
+              const SizedBox(width: AppSpacing.grid),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: subtitle == null
+                      ? MainAxisAlignment.center
+                      : MainAxisAlignment.spaceEvenly,
+                  children: [
+                    DefaultTextStyle.merge(
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.textPrimary,
+                      ),
+                      child: title,
+                    ),
+                    if (subtitle != null)
+                      DefaultTextStyle.merge(
+                        style: AppTypography.secondary,
+                        child: subtitle!,
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSpacing.grid),
+              const Icon(Icons.chevron_right, color: AppColors.textSecondary),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/components/category_tile.dart
+++ b/lib/ui/components/category_tile.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+import 'card_tile.dart';
+
+class CategoryTile extends StatelessWidget {
+  const CategoryTile({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.progress,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final double progress;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return CardTile(
+      leading: Icon(icon, color: AppColors.accentSecondary, size: 28),
+      title: Text(title),
+      subtitle: ClipRRect(
+        borderRadius: BorderRadius.circular(999),
+        child: LinearProgressIndicator(
+          value: progress,
+          minHeight: AppComponentSpecs.progressBarHeight,
+          backgroundColor: AppColors.borderMuted,
+          valueColor:
+              const AlwaysStoppedAnimation<Color>(AppColors.accentSecondary),
+        ),
+      ),
+      height: 72,
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/ui/components/hint_button.dart
+++ b/lib/ui/components/hint_button.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+
+class HintButton extends StatelessWidget {
+  const HintButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        foregroundColor: AppColors.textPrimary,
+        side: const BorderSide(color: AppColors.borderMuted),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        shape: RoundedRectangleBorder(borderRadius: AppRadius.medium),
+        textStyle: const TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      child: Text(label),
+    );
+  }
+}

--- a/lib/ui/components/primary_button.dart
+++ b/lib/ui/components/primary_button.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+
+class PrimaryButton extends StatelessWidget {
+  const PrimaryButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: AppComponentSpecs.primaryButtonHeight,
+      width: double.infinity,
+      child: FilledButton(
+        onPressed: onPressed,
+        style: FilledButton.styleFrom(
+          backgroundColor: AppColors.accentPrimary,
+          foregroundColor: Colors.black,
+          textStyle: const TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: AppRadius.medium,
+          ),
+        ),
+        child: Text(label),
+      ),
+    );
+  }
+}

--- a/lib/ui/components/resource_chip.dart
+++ b/lib/ui/components/resource_chip.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+
+class ResourceChip extends StatelessWidget {
+  const ResourceChip({
+    super.key,
+    required this.icon,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 12,
+        vertical: 6,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.bgElevated,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.borderMuted),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18, color: AppColors.accentSecondary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: AppTypography.chip,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/components/result_sheet.dart
+++ b/lib/ui/components/result_sheet.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+import 'primary_button.dart';
+
+class ResultSheet extends StatelessWidget {
+  const ResultSheet({
+    super.key,
+    required this.playerAnswer,
+    required this.correctAnswer,
+    required this.delta,
+    required this.points,
+    required this.onNext,
+    required this.onDetails,
+    this.isLast = false,
+  });
+
+  final int playerAnswer;
+  final int correctAnswer;
+  final int delta;
+  final int points;
+  final VoidCallback onNext;
+  final VoidCallback onDetails;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.screenPadding),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(AppSpacing.grid),
+            decoration: BoxDecoration(
+              color: AppColors.bgElevated,
+              borderRadius: AppRadius.medium,
+              border: Border.all(color: AppColors.borderMuted),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Твой ответ: $playerAnswer', style: theme.textTheme.bodyLarge),
+                const SizedBox(height: 8),
+                Text('Правильный ответ: $correctAnswer',
+                    style: theme.textTheme.bodyLarge),
+                const SizedBox(height: 8),
+                Text('Δ $delta лет', style: theme.textTheme.bodyLarge),
+                const SizedBox(height: 8),
+                Text('Очки: +$points',
+                    style: theme.textTheme.bodyLarge
+                        ?.copyWith(color: AppColors.success)),
+                const SizedBox(height: 12),
+                Text(
+                  'Факт: Краткое описание события.',
+                  style: AppTypography.secondary,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.grid * 1.5),
+          PrimaryButton(
+            label: isLast ? 'Завершить' : 'Дальше',
+            onPressed: onNext,
+          ),
+          const SizedBox(height: AppSpacing.grid),
+          TextButton(
+            onPressed: onDetails,
+            child: const Text('Подробнее'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/components/secondary_text_button.dart
+++ b/lib/ui/components/secondary_text_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+
+class SecondaryTextButton extends StatelessWidget {
+  const SecondaryTextButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: onPressed,
+      style: TextButton.styleFrom(
+        foregroundColor: AppColors.accentSecondary,
+        textStyle: const TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      child: Text(label),
+    );
+  }
+}

--- a/lib/ui/components/timeline_slider.dart
+++ b/lib/ui/components/timeline_slider.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import '../tokens.dart';
+
+class TimelineSlider extends StatelessWidget {
+  const TimelineSlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final double value;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.grid),
+      decoration: BoxDecoration(
+        color: AppColors.bgElevated,
+        borderRadius: AppRadius.medium,
+        border: Border.all(color: AppColors.borderMuted),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              trackHeight: 6,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 10),
+            ),
+            child: Slider(
+              min: 0,
+              max: 2024,
+              value: value,
+              onChanged: onChanged,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: const [
+              Text('I', style: TextStyle(color: AppColors.textSecondary)),
+              Text('V', style: TextStyle(color: AppColors.textSecondary)),
+              Text('X', style: TextStyle(color: AppColors.textSecondary)),
+              Text('XV', style: TextStyle(color: AppColors.textSecondary)),
+              Text('XX', style: TextStyle(color: AppColors.textSecondary)),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(color: AppColors.borderMuted),
+              ),
+              child: const Text(
+                'CE',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/categories_screen.dart
+++ b/lib/ui/screens/categories_screen.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../components/app_top_bar.dart';
+import '../components/category_tile.dart';
+import '../components/primary_button.dart';
+import '../components/resource_chip.dart';
+import '../tokens.dart';
+
+class CategoriesScreen extends StatelessWidget {
+  const CategoriesScreen({super.key});
+
+  static const _categories = [
+    ('history', 'History', Icons.timeline),
+    ('culture', 'Culture', Icons.palette_outlined),
+    ('movies', 'Movies', Icons.movie_outlined),
+    ('art', 'Art', Icons.brush_outlined),
+    ('games', 'Games', Icons.sports_esports_outlined),
+    ('music', 'Music', Icons.music_note_outlined),
+    ('sport', 'Sport', Icons.sports_soccer),
+    ('world', 'World', Icons.public),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppTopBar(
+        leading: IconButton(
+          onPressed: () => context.pop(),
+          icon: const Icon(Icons.arrow_back),
+        ),
+        title: const Text('Категории'),
+        actions: const [
+          ResourceChip(icon: Icons.favorite, label: '5'),
+          ResourceChip(icon: Icons.flash_on, label: '120'),
+          ResourceChip(icon: Icons.ac_unit, label: '42'),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.separated(
+              padding: const EdgeInsets.all(AppSpacing.screenPadding),
+              itemBuilder: (context, index) {
+                final category = _categories[index];
+                return CategoryTile(
+                  icon: category.$3,
+                  title: category.$2,
+                  progress: 0.2 + index * 0.08,
+                  onTap: () => context.go('/round/${category.$1}'),
+                );
+              },
+              separatorBuilder: (_, __) => const SizedBox(height: AppSpacing.grid),
+              itemCount: _categories.length,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.screenPadding,
+              0,
+              AppSpacing.screenPadding,
+              AppSpacing.screenPadding,
+            ),
+            child: PrimaryButton(
+              label: 'Назад',
+              onPressed: () => context.go('/home'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../components/app_top_bar.dart';
+import '../components/card_tile.dart';
+import '../components/primary_button.dart';
+import '../components/resource_chip.dart';
+import '../components/secondary_text_button.dart';
+import '../tokens.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppTopBar(
+        leading: IconButton(
+          onPressed: () {},
+          icon: const Icon(Icons.menu),
+        ),
+        title: const Text('DataG Trivia'),
+        actions: const [
+          ResourceChip(icon: Icons.favorite, label: '5'),
+          ResourceChip(icon: Icons.flash_on, label: '120'),
+          ResourceChip(icon: Icons.ac_unit, label: '42'),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(AppSpacing.screenPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            CardTile(
+              leading: const Icon(Icons.local_fire_department,
+                  color: AppColors.accentSecondary, size: 32),
+              title: const Text('Неделя X'),
+              subtitle: LinearProgressIndicator(
+                value: 0.45,
+                minHeight: AppComponentSpecs.progressBarHeight,
+                backgroundColor: AppColors.borderMuted,
+                valueColor: const AlwaysStoppedAnimation<Color>(
+                  AppColors.accentSecondary,
+                ),
+              ),
+              onTap: () => context.go('/stub?title=Событие'),
+            ),
+            const SizedBox(height: AppSpacing.grid),
+            CardTile(
+              leading: const Icon(Icons.group,
+                  color: AppColors.accentSecondary, size: 32),
+              title: const Text('Играй с друзьями'),
+              onTap: () => context.go('/stub?title=Друзья'),
+            ),
+            const SizedBox(height: AppSpacing.grid * 1.5),
+            PrimaryButton(
+              label: 'Играть',
+              onPressed: () => context.go('/round/history'),
+            ),
+            const SizedBox(height: 8),
+            SecondaryTextButton(
+              label: 'Сменить категорию',
+              onPressed: () => context.go('/categories'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/round_screen.dart
+++ b/lib/ui/screens/round_screen.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../components/app_top_bar.dart';
+import '../components/hint_button.dart';
+import '../components/primary_button.dart';
+import '../components/resource_chip.dart';
+import '../components/result_sheet.dart';
+import '../components/timeline_slider.dart';
+import '../tokens.dart';
+
+class RoundQuestion {
+  const RoundQuestion({
+    required this.fact,
+    required this.answerYear,
+    required this.highlight,
+  });
+
+  final String fact;
+  final String highlight;
+  final int answerYear;
+}
+
+class RoundScreen extends StatefulWidget {
+  const RoundScreen({super.key, required this.categoryId});
+
+  final String categoryId;
+
+  @override
+  State<RoundScreen> createState() => _RoundScreenState();
+}
+
+class _RoundScreenState extends State<RoundScreen> {
+  static const _questions = [
+    RoundQuestion(
+      fact: 'Когда произошла битва при',
+      highlight: 'Гастингсе?',
+      answerYear: 1066,
+    ),
+    RoundQuestion(
+      fact: 'В каком году была создана',
+      highlight: 'первaя телеграмма?',
+      answerYear: 1844,
+    ),
+    RoundQuestion(
+      fact: 'Когда состоялась премьера',
+      highlight: 'первого фильма Lumière?',
+      answerYear: 1895,
+    ),
+  ];
+
+  int _currentQuestion = 0;
+  double _selectedYear = 1500;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedYear = _questions.first.answerYear.toDouble();
+  }
+
+  void _adjustYear(int delta) {
+    setState(() {
+      _selectedYear = (_selectedYear + delta).clamp(0, 2024);
+    });
+  }
+
+  Future<void> _showResult() async {
+    final question = _questions[_currentQuestion];
+    final answer = _selectedYear.round();
+    final delta = (answer - question.answerYear).abs();
+    final isLast = _currentQuestion == _questions.length - 1;
+
+    final result = await showModalBottomSheet<bool>(
+      context: context,
+      backgroundColor: AppColors.bgBase,
+      isScrollControlled: true,
+      builder: (context) => ResultSheet(
+        playerAnswer: answer,
+        correctAnswer: question.answerYear,
+        delta: delta,
+        points: (100 - delta).clamp(10, 100).toInt(),
+        isLast: isLast,
+        onNext: () => Navigator.of(context).pop(true),
+        onDetails: () => Navigator.of(context).pop(false),
+      ),
+    );
+
+    if (!mounted || result == null) return;
+
+    if (!result) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Экран с подробностями появится позже.')),
+      );
+      return;
+    }
+
+    if (isLast) {
+      context.go('/summary');
+      return;
+    }
+
+    setState(() {
+      _currentQuestion = (_currentQuestion + 1) % _questions.length;
+      _selectedYear = _questions[_currentQuestion].answerYear.toDouble();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final question = _questions[_currentQuestion];
+    final progress = (_currentQuestion + 1) / _questions.length;
+
+    return Scaffold(
+      appBar: AppTopBar(
+        title: Text('${_currentQuestion + 1}/${_questions.length}'),
+        actions: const [
+          ResourceChip(icon: Icons.favorite, label: '5'),
+          ResourceChip(icon: Icons.flash_on, label: '120'),
+          ResourceChip(icon: Icons.ac_unit, label: '42'),
+        ],
+      ),
+      body: Column(
+        children: [
+          LinearProgressIndicator(
+            value: progress,
+            minHeight: AppComponentSpecs.progressBarHeight,
+            backgroundColor: AppColors.borderMuted,
+            valueColor: const AlwaysStoppedAnimation<Color>(
+              AppColors.accentSecondary,
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.screenPadding),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: AppSpacing.grid),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        RichText(
+                          textAlign: TextAlign.center,
+                          text: TextSpan(
+                            style: AppTypography.h2Fact,
+                            children: [
+                              TextSpan(text: '${question.fact} '),
+                              TextSpan(
+                                text: question.highlight,
+                                style: AppTypography.h2FactEmphasis(context),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.grid * 2),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            _YearControlButton(
+                              icon: Icons.remove,
+                              onPressed: () => _adjustYear(-1),
+                            ),
+                            const SizedBox(width: AppSpacing.grid * 1.5),
+                            Text(
+                              _selectedYear.round().toString(),
+                              style: AppTypography.h1Year,
+                            ),
+                            const SizedBox(width: AppSpacing.grid * 1.5),
+                            _YearControlButton(
+                              icon: Icons.add,
+                              onPressed: () => _adjustYear(1),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: AppSpacing.grid * 1.5),
+                        TimelineSlider(
+                          value: _selectedYear,
+                          onChanged: (value) => setState(() {
+                            _selectedYear = value;
+                          }),
+                        ),
+                        const SizedBox(height: AppSpacing.grid * 1.5),
+                        Wrap(
+                          spacing: AppSpacing.grid,
+                          runSpacing: AppSpacing.grid,
+                          alignment: WrapAlignment.center,
+                          children: const [
+                            HintButton(label: 'Last'),
+                            HintButton(label: 'A/B'),
+                            HintButton(label: 'Narrow'),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SafeArea(
+            minimum: const EdgeInsets.all(AppSpacing.screenPadding),
+            child: PrimaryButton(
+              label: 'Проверить дату',
+              onPressed: _showResult,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _YearControlButton extends StatelessWidget {
+  const _YearControlButton({required this.icon, required this.onPressed});
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: AppComponentSpecs.minTouchTarget,
+      height: AppComponentSpecs.minTouchTarget,
+      child: OutlinedButton(
+        onPressed: onPressed,
+        style: OutlinedButton.styleFrom(
+          shape: const CircleBorder(),
+          side: const BorderSide(color: AppColors.borderMuted),
+          padding: EdgeInsets.zero,
+        ),
+        child: Icon(icon, color: AppColors.textPrimary),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/stub_screen.dart
+++ b/lib/ui/screens/stub_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../components/app_top_bar.dart';
+
+class StubScreen extends StatelessWidget {
+  const StubScreen({super.key, required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppTopBar(
+        leading: IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back),
+        ),
+        title: Text(title),
+      ),
+      body: Center(
+        child: Text(
+          '$title screen coming soon',
+          style: const TextStyle(fontSize: 18),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/summary_screen.dart
+++ b/lib/ui/screens/summary_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../components/app_top_bar.dart';
+import '../components/primary_button.dart';
+import '../components/secondary_text_button.dart';
+import '../tokens.dart';
+
+class SummaryScreen extends StatelessWidget {
+  const SummaryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppTopBar(
+        leading: IconButton(
+          onPressed: () => context.go('/home'),
+          icon: const Icon(Icons.close),
+        ),
+        title: const Text('Итоги'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppSpacing.screenPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: AppSpacing.grid * 2),
+            const Text(
+              'Раунд завершён!',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.grid * 2),
+            const Text(
+              '1 250 очков',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 32,
+                fontWeight: FontWeight.w700,
+                color: AppColors.accentPrimary,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.grid * 2),
+            Container(
+              padding: const EdgeInsets.all(AppSpacing.grid),
+              decoration: BoxDecoration(
+                color: AppColors.bgElevated,
+                borderRadius: AppRadius.medium,
+                border: Border.all(color: AppColors.borderMuted),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: const [
+                  Text('Правильно: 7/10', style: AppTypography.secondary),
+                  SizedBox(height: 8),
+                  Text('Средняя дельта: 12 лет', style: AppTypography.secondary),
+                ],
+              ),
+            ),
+            const Spacer(),
+            PrimaryButton(
+              label: 'Играть снова',
+              onPressed: () => context.go('/round/history'),
+            ),
+            const SizedBox(height: 8),
+            SecondaryTextButton(
+              label: 'Домой',
+              onPressed: () => context.go('/home'),
+            ),
+            const SizedBox(height: AppSpacing.grid),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: datag
+description: MVP UI scaffolding for DataG trivia game.
+publish_to: "none"
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  go_router: ^14.1.4
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a Flutter entrypoint configured with go_router routes for the home, categories, round, summary, and stub flows
- scaffold the home, categories, round, and summary screens with the layout and interactions described in the MVP brief
- build reusable UI components such as the shared top bar, resource chips, card tiles, buttons, timeline slider, and result sheet, and add the pubspec with required dependencies

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9a024eca88326b05213b8d6fe037f