### PR TITLE
Implement round gameplay logic and state management

### DIFF
--- a/assets/questions.json
+++ b/assets/questions.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "hist_kyivan_rus_baptism",
+    "prompt": "Крещение Киевской Руси",
+    "correctYear": 988,
+    "minYear": 700,
+    "maxYear": 1200,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Владимир Святославич", "Принятие христианства", "Днепр"]
+  },
+  {
+    "id": "hist_fall_of_rome",
+    "prompt": "Падение Западной Римской империи",
+    "correctYear": 476,
+    "minYear": 200,
+    "maxYear": 800,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Од варваров", "Одоакр", "Последний император"]
+  },
+  {
+    "id": "hist_magna_carta",
+    "prompt": "Подписание Великой хартии вольностей",
+    "correctYear": 1215,
+    "minYear": 1000,
+    "maxYear": 1500,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Англия", "Иоанн Безземельный", "Права баронов"]
+  },
+  {
+    "id": "hist_columbus_america",
+    "prompt": "Экспедиция Колумба к берегам Америки",
+    "correctYear": 1492,
+    "minYear": 1200,
+    "maxYear": 1700,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Новый Свет", "Испания", "Генуя"]
+  },
+  {
+    "id": "hist_french_revolution",
+    "prompt": "Взятие Бастилии и начало Французской революции",
+    "correctYear": 1789,
+    "minYear": 1600,
+    "maxYear": 1900,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Париж", "Людовик XVI", "Свобода"]
+  },
+  {
+    "id": "hist_industrial_revolution",
+    "prompt": "Первое промышленное революционное ткачество",
+    "correctYear": 1764,
+    "minYear": 1500,
+    "maxYear": 1900,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Прялка Дженни", "Великобритания", "Мануфактуры"]
+  },
+  {
+    "id": "hist_battle_of_hastings",
+    "prompt": "Битва при Гастингсе",
+    "correctYear": 1066,
+    "minYear": 800,
+    "maxYear": 1300,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Вильгельм Завоеватель", "Нормандское завоевание", "Англия"]
+  },
+  {
+    "id": "hist_printing_press",
+    "prompt": "Иоганн Гутенберг завершает печатный станок",
+    "correctYear": 1450,
+    "minYear": 1200,
+    "maxYear": 1600,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Майнц", "Библия", "Типография"]
+  },
+  {
+    "id": "hist_moon_landing",
+    "prompt": "Высадка человека на Луну",
+    "correctYear": 1969,
+    "minYear": 1900,
+    "maxYear": 2020,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["NASA", "Аполлон-11", "Нил Армстронг"]
+  },
+  {
+    "id": "hist_berlin_wall_fall",
+    "prompt": "Падение Берлинской стены",
+    "correctYear": 1989,
+    "minYear": 1940,
+    "maxYear": 2020,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["ГДР", "Перестройка", "Холодная война"]
+  },
+  {
+    "id": "hist_printing_decl_of_independence",
+    "prompt": "Подписание Декларации независимости США",
+    "correctYear": 1776,
+    "minYear": 1600,
+    "maxYear": 1900,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Филадельфия", "Колонии", "4 июля"]
+  },
+  {
+    "id": "hist_renaissance_david",
+    "prompt": "Микеланджело завершает Давида",
+    "correctYear": 1504,
+    "minYear": 1200,
+    "maxYear": 1700,
+    "era": "CE",
+    "categoryId": "history",
+    "hints": ["Флоренция", "Мрамор", "Скульптура"]
+  },
+  {
+    "id": "culture_first_grammy",
+    "prompt": "Первая церемония вручения премии Грэмми",
+    "correctYear": 1959,
+    "minYear": 1900,
+    "maxYear": 2020,
+    "era": "CE",
+    "categoryId": "culture",
+    "hints": ["США", "Музыка", "Grammy"]
+  },
+  {
+    "id": "movies_star_wars",
+    "prompt": "Премьера фильма 'Звёздные войны: Новая надежда'",
+    "correctYear": 1977,
+    "minYear": 1950,
+    "maxYear": 2020,
+    "era": "CE",
+    "categoryId": "movies",
+    "hints": ["Джордж Лукас", "Эпизод IV", "Научная фантастика"]
+  }
+]

--- a/lib/data/question_repository.dart
+++ b/lib/data/question_repository.dart
@@ -1,0 +1,34 @@
+import 'dart:math';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../models/question.dart';
+
+class QuestionRepository {
+  QuestionRepository();
+
+  List<Question>? _cache;
+
+  Future<List<Question>> _loadAll() async {
+    if (_cache != null) {
+      return _cache!;
+    }
+    final raw = await rootBundle.loadString('assets/questions.json');
+    _cache = Question.parseList(raw);
+    return _cache!;
+  }
+
+  Future<List<Question>> loadByCategory(String categoryId, {int limit = 10}) async {
+    final all = await _loadAll();
+    final filtered = all.where((q) => q.categoryId == categoryId).toList();
+    if (filtered.isEmpty) {
+      return [];
+    }
+    final random = Random(categoryId.hashCode);
+    filtered.shuffle(random);
+    if (filtered.length <= limit) {
+      return filtered;
+    }
+    return filtered.sublist(0, limit);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'ui/screens/categories_screen.dart';
@@ -7,9 +8,10 @@ import 'ui/screens/round_screen.dart';
 import 'ui/screens/summary_screen.dart';
 import 'ui/screens/stub_screen.dart';
 import 'ui/tokens.dart';
+import 'ui/state/round_controller.dart';
 
 void main() {
-  runApp(const DataGApp());
+  runApp(const ProviderScope(child: DataGApp()));
 }
 
 class DataGApp extends StatelessWidget {
@@ -37,7 +39,10 @@ class DataGApp extends StatelessWidget {
         ),
         GoRoute(
           path: '/summary',
-          builder: (context, state) => const SummaryScreen(),
+          builder: (context, state) {
+            final summary = state.extra as RoundSummary?;
+            return SummaryScreen(summary: summary);
+          },
         ),
         GoRoute(
           path: '/stub',

--- a/lib/models/question.dart
+++ b/lib/models/question.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+enum Era { bce, ce }
+
+extension EraX on Era {
+  static Era fromString(String value) {
+    switch (value.toUpperCase()) {
+      case 'BCE':
+        return Era.bce;
+      case 'CE':
+      default:
+        return Era.ce;
+    }
+  }
+
+  String get label => this == Era.bce ? 'BCE' : 'CE';
+
+  String get localizedLabel => this == Era.bce ? 'до н. э.' : 'н. э.';
+
+  int signedYear(int year) => this == Era.bce ? -year : year;
+}
+
+class Question {
+  Question({
+    required this.id,
+    required this.prompt,
+    required this.correctYear,
+    required this.minYear,
+    required this.maxYear,
+    required this.era,
+    required this.categoryId,
+    required this.hints,
+  });
+
+  factory Question.fromJson(Map<String, dynamic> json) {
+    return Question(
+      id: json['id'] as String,
+      prompt: json['prompt'] as String,
+      correctYear: json['correctYear'] as int,
+      minYear: json['minYear'] as int,
+      maxYear: json['maxYear'] as int,
+      era: EraX.fromString(json['era'] as String),
+      categoryId: json['categoryId'] as String,
+      hints: (json['hints'] as List<dynamic>? ?? const [])
+          .map((e) => e.toString())
+          .toList(),
+    );
+  }
+
+  static List<Question> parseList(String jsonStr) {
+    final dynamic data = jsonDecode(jsonStr);
+    if (data is List<dynamic>) {
+      return data
+          .map((e) => Question.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw const FormatException('Unexpected questions format');
+  }
+
+  final String id;
+  final String prompt;
+  final int correctYear;
+  final int minYear;
+  final int maxYear;
+  final Era era;
+  final String categoryId;
+  final List<String> hints;
+
+  int get range => maxYear - minYear;
+
+  int get defaultYear => ((minYear + maxYear) / 2).round();
+}

--- a/lib/ui/components/hint_button.dart
+++ b/lib/ui/components/hint_button.dart
@@ -18,6 +18,7 @@ class HintButton extends StatelessWidget {
       onPressed: onPressed,
       style: OutlinedButton.styleFrom(
         foregroundColor: AppColors.textPrimary,
+        disabledForegroundColor: AppColors.textSecondary,
         side: const BorderSide(color: AppColors.borderMuted),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         shape: RoundedRectangleBorder(borderRadius: AppRadius.medium),

--- a/lib/ui/components/result_sheet.dart
+++ b/lib/ui/components/result_sheet.dart
@@ -1,31 +1,45 @@
 import 'package:flutter/material.dart';
 
+import '../../models/question.dart';
+import '../state/round_controller.dart';
 import '../tokens.dart';
 import 'primary_button.dart';
 
 class ResultSheet extends StatelessWidget {
   const ResultSheet({
     super.key,
-    required this.playerAnswer,
-    required this.correctAnswer,
-    required this.delta,
-    required this.points,
+    required this.result,
+    required this.isLast,
     required this.onNext,
     required this.onDetails,
-    this.isLast = false,
   });
 
-  final int playerAnswer;
-  final int correctAnswer;
-  final int delta;
-  final int points;
+  final QuestionResult result;
+  final bool isLast;
   final VoidCallback onNext;
   final VoidCallback onDetails;
-  final bool isLast;
+
+  String get _deltaText {
+    if (result.delta == 0) {
+      return 'Вы попали точно!';
+    }
+    return 'Вы промахнулись на ${result.delta} ${_pluralYears(result.delta)}';
+  }
+
+  String get _pointsText {
+    final points = result.netPoints;
+    final prefix = points >= 0 ? '+' : '';
+    return '$prefix$points';
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final bonus = result.totalPoints - result.baseScore;
+    final hints = result.usedHints.isEmpty
+        ? 'Без подсказок'
+        : 'Подсказки: ${result.usedHints.map(_hintLabel).join(', ')}';
+
     return Padding(
       padding: const EdgeInsets.all(AppSpacing.screenPadding),
       child: Column(
@@ -42,21 +56,58 @@ class ResultSheet extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('Твой ответ: $playerAnswer', style: theme.textTheme.bodyLarge),
-                const SizedBox(height: 8),
-                Text('Правильный ответ: $correctAnswer',
-                    style: theme.textTheme.bodyLarge),
-                const SizedBox(height: 8),
-                Text('Δ $delta лет', style: theme.textTheme.bodyLarge),
-                const SizedBox(height: 8),
-                Text('Очки: +$points',
-                    style: theme.textTheme.bodyLarge
-                        ?.copyWith(color: AppColors.success)),
-                const SizedBox(height: 12),
                 Text(
-                  'Факт: Краткое описание события.',
+                  'Твой ответ: ${result.playerYear} ${result.playerEra.label}',
+                  style: theme.textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Правильный ответ: ${result.question.correctYear} ${result.question.era.label}',
+                  style: theme.textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  _deltaText,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Базовые очки: ${result.baseScore}',
                   style: AppTypography.secondary,
                 ),
+                Text(
+                  'Бонусы: ${bonus >= 0 ? '+$bonus' : bonus}',
+                  style: AppTypography.secondary,
+                ),
+                if (result.hintPenalty > 0) ...[
+                  Text(
+                    'Штраф за подсказки: -${result.hintPenalty}',
+                    style: AppTypography.secondary,
+                  ),
+                ],
+                const SizedBox(height: 8),
+                Text(
+                  'Очки за вопрос: $_pointsText',
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: result.netPoints >= 0
+                        ? AppColors.success
+                        : AppColors.error,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  hints,
+                  style: AppTypography.secondary,
+                ),
+                if (result.streakBoostApplied)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      'Серия ${result.streakAfterAnswer}: множитель 1.5×!',
+                      style: AppTypography.secondary,
+                    ),
+                  ),
               ],
             ),
           ),
@@ -73,5 +124,26 @@ class ResultSheet extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _hintLabel(HintType type) {
+    switch (type) {
+      case HintType.lastDigits:
+        return 'Last digits';
+      case HintType.abQuiz:
+        return 'A/B';
+      case HintType.narrowTimeline:
+        return 'Narrow';
+    }
+  }
+
+  String _pluralYears(int value) {
+    final mod10 = value % 10;
+    final mod100 = value % 100;
+    if (mod10 == 1 && mod100 != 11) return 'год';
+    if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) {
+      return 'года';
+    }
+    return 'лет';
   }
 }

--- a/lib/ui/components/timeline_slider.dart
+++ b/lib/ui/components/timeline_slider.dart
@@ -1,19 +1,50 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
+import '../../models/question.dart';
 import '../tokens.dart';
 
 class TimelineSlider extends StatelessWidget {
   const TimelineSlider({
     super.key,
+    required this.minYear,
+    required this.maxYear,
     required this.value,
+    required this.correctYear,
+    required this.correctEra,
+    required this.era,
     required this.onChanged,
+    this.onEraChanged,
   });
 
-  final double value;
-  final ValueChanged<double> onChanged;
+  final int minYear;
+  final int maxYear;
+  final int value;
+  final int correctYear;
+  final Era correctEra;
+  final Era era;
+  final ValueChanged<int> onChanged;
+  final ValueChanged<Era>? onEraChanged;
+
+  double get _heat {
+    final selectedSigned = era.signedYear(value);
+    final correctSigned = correctEra.signedYear(correctYear);
+    final rangeSpan = max(1, (maxYear - minYear).abs());
+    final distance = (selectedSigned - correctSigned).abs();
+    return (1 - (distance / rangeSpan)).clamp(0, 1).toDouble();
+  }
 
   @override
   Widget build(BuildContext context) {
+    final divisions = max(1, maxYear - minYear);
+    final heatColor = Color.lerp(
+      AppColors.accentSecondary.withOpacity(0.4),
+      AppColors.accentPrimary,
+      _heat,
+    )!;
+    final inactiveTrack = AppColors.borderMuted.withOpacity(0.6);
+
     return Container(
       padding: const EdgeInsets.all(AppSpacing.grid),
       decoration: BoxDecoration(
@@ -27,46 +58,215 @@ class TimelineSlider extends StatelessWidget {
           SliderTheme(
             data: SliderTheme.of(context).copyWith(
               trackHeight: 6,
+              activeTrackColor: heatColor,
+              inactiveTrackColor: inactiveTrack,
+              overlayColor: heatColor.withOpacity(0.2),
+              thumbColor: heatColor,
+              valueIndicatorColor: AppColors.accentPrimary,
               thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 10),
             ),
             child: Slider(
-              min: 0,
-              max: 2024,
-              value: value,
-              onChanged: onChanged,
+              min: minYear.toDouble(),
+              max: maxYear.toDouble(),
+              divisions: divisions,
+              value: value.clamp(minYear, maxYear).toDouble(),
+              label: '$value ${era.label}',
+              onChanged: (newValue) => onChanged(newValue.round()),
             ),
           ),
-          const SizedBox(height: 8),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: const [
-              Text('I', style: TextStyle(color: AppColors.textSecondary)),
-              Text('V', style: TextStyle(color: AppColors.textSecondary)),
-              Text('X', style: TextStyle(color: AppColors.textSecondary)),
-              Text('XV', style: TextStyle(color: AppColors.textSecondary)),
-              Text('XX', style: TextStyle(color: AppColors.textSecondary)),
-            ],
+          const SizedBox(height: 12),
+          SizedBox(
+            height: 32,
+            child: CustomPaint(
+              painter: _TimelineTicksPainter(
+                minYear: minYear,
+                maxYear: maxYear,
+              ),
+            ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: 12),
+          _CenturyLabels(minYear: minYear, maxYear: maxYear, era: era),
+          const SizedBox(height: 12),
           Align(
             alignment: Alignment.centerRight,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(20),
-                border: Border.all(color: AppColors.borderMuted),
-              ),
-              child: const Text(
-                'CE',
-                style: TextStyle(
-                  fontSize: 13,
-                  color: AppColors.textSecondary,
+            child: ToggleButtons(
+              isSelected: [era == Era.bce, era == Era.ce],
+              onPressed: onEraChanged == null
+                  ? null
+                  : (index) => onEraChanged!(index == 0 ? Era.bce : Era.ce),
+              borderRadius: BorderRadius.circular(20),
+              borderColor: AppColors.borderMuted,
+              selectedBorderColor: AppColors.accentSecondary,
+              fillColor: AppColors.accentSecondary.withOpacity(0.2),
+              selectedColor: AppColors.accentSecondary,
+              textStyle: const TextStyle(fontSize: 13),
+              children: const [
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  child: Text('BCE'),
                 ),
-              ),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  child: Text('CE'),
+                ),
+              ],
             ),
           ),
         ],
       ),
     );
   }
+}
+
+class _TimelineTicksPainter extends CustomPainter {
+  const _TimelineTicksPainter({
+    required this.minYear,
+    required this.maxYear,
+  });
+
+  final int minYear;
+  final int maxYear;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final total = max(1, maxYear - minYear);
+    final paint = Paint()
+      ..color = AppColors.borderMuted
+      ..strokeWidth = 1;
+    for (int offset = 0; offset <= total; offset++) {
+      final year = minYear + offset;
+      final dx = size.width * (offset / total);
+      final tickHeight = year % 10 == 0
+          ? size.height
+          : year % 5 == 0
+              ? size.height * 0.65
+              : size.height * 0.4;
+      canvas.drawLine(
+        Offset(dx, size.height - tickHeight),
+        Offset(dx, size.height),
+        paint,
+      );
+      if (year % 10 == 0) {
+        final textPainter = TextPainter(
+          text: TextSpan(
+            text: year.toString(),
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 10,
+            ),
+          ),
+          textDirection: TextDirection.ltr,
+        )..layout();
+        textPainter.paint(
+          canvas,
+          Offset(dx - textPainter.width / 2, 0),
+        );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _TimelineTicksPainter oldDelegate) {
+    return oldDelegate.minYear != minYear || oldDelegate.maxYear != maxYear;
+  }
+}
+
+class _CenturyLabels extends StatelessWidget {
+  const _CenturyLabels({
+    required this.minYear,
+    required this.maxYear,
+    required this.era,
+  });
+
+  final int minYear;
+  final int maxYear;
+  final Era era;
+
+  @override
+  Widget build(BuildContext context) {
+    final centuries = _buildCenturies();
+    if (centuries.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: centuries
+          .map(
+            (century) => Text(
+              '${century.roman} (${century.start}–${century.end}) ${era.label}',
+              style: const TextStyle(
+                fontSize: 12,
+                color: AppColors.textSecondary,
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  List<_CenturyData> _buildCenturies() {
+    final startCentury = _centuryForYear(minYear);
+    final endCentury = _centuryForYear(maxYear);
+    final centuries = <_CenturyData>[];
+    for (int century = startCentury; century <= endCentury; century++) {
+      final start = max(minYear, _centuryStart(century));
+      final end = min(maxYear, _centuryEnd(century));
+      centuries.add(
+        _CenturyData(
+          roman: _toRoman(century),
+          start: start,
+          end: end,
+        ),
+      );
+    }
+    return centuries;
+  }
+
+  int _centuryForYear(int year) {
+    final safeYear = max(1, year);
+    return ((safeYear - 1) ~/ 100) + 1;
+  }
+
+  int _centuryStart(int century) => (century - 1) * 100;
+
+  int _centuryEnd(int century) => century * 100 - 1;
+
+  String _toRoman(int value) {
+    const numerals = {
+      1000: 'M',
+      900: 'CM',
+      500: 'D',
+      400: 'CD',
+      100: 'C',
+      90: 'XC',
+      50: 'L',
+      40: 'XL',
+      10: 'X',
+      9: 'IX',
+      5: 'V',
+      4: 'IV',
+      1: 'I',
+    };
+    var number = value;
+    final buffer = StringBuffer();
+    for (final entry in numerals.entries) {
+      while (number >= entry.key) {
+        buffer.write(entry.value);
+        number -= entry.key;
+      }
+    }
+    return buffer.toString();
+  }
+}
+
+class _CenturyData {
+  const _CenturyData({
+    required this.roman,
+    required this.start,
+    required this.end,
+  });
+
+  final String roman;
+  final int start;
+  final int end;
 }

--- a/lib/ui/screens/round_screen.dart
+++ b/lib/ui/screens/round_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../models/question.dart';
 import '../components/app_top_bar.dart';
 import '../components/hint_button.dart';
 import '../components/primary_button.dart';
@@ -8,115 +11,129 @@ import '../components/resource_chip.dart';
 import '../components/result_sheet.dart';
 import '../components/timeline_slider.dart';
 import '../tokens.dart';
+import '../state/round_controller.dart';
 
-class RoundQuestion {
-  const RoundQuestion({
-    required this.fact,
-    required this.answerYear,
-    required this.highlight,
-  });
-
-  final String fact;
-  final String highlight;
-  final int answerYear;
-}
-
-class RoundScreen extends StatefulWidget {
+class RoundScreen extends ConsumerStatefulWidget {
   const RoundScreen({super.key, required this.categoryId});
 
   final String categoryId;
 
   @override
-  State<RoundScreen> createState() => _RoundScreenState();
+  ConsumerState<RoundScreen> createState() => _RoundScreenState();
 }
 
-class _RoundScreenState extends State<RoundScreen> {
-  static const _questions = [
-    RoundQuestion(
-      fact: 'Когда произошла битва при',
-      highlight: 'Гастингсе?',
-      answerYear: 1066,
-    ),
-    RoundQuestion(
-      fact: 'В каком году была создана',
-      highlight: 'первaя телеграмма?',
-      answerYear: 1844,
-    ),
-    RoundQuestion(
-      fact: 'Когда состоялась премьера',
-      highlight: 'первого фильма Lumière?',
-      answerYear: 1895,
-    ),
-  ];
+class _RoundScreenState extends ConsumerState<RoundScreen> {
+  int? _lastHapticValue;
 
-  int _currentQuestion = 0;
-  double _selectedYear = 1500;
+  RoundController get _controller =>
+      ref.read(roundControllerProvider(widget.categoryId).notifier);
 
-  @override
-  void initState() {
-    super.initState();
-    _selectedYear = _questions.first.answerYear.toDouble();
-  }
+  RoundState get _state => ref.read(roundControllerProvider(widget.categoryId));
 
   void _adjustYear(int delta) {
-    setState(() {
-      _selectedYear = (_selectedYear + delta).clamp(0, 2024);
-    });
+    _controller.adjustYear(delta);
+    _emitHaptics(_state.selectedYear);
+  }
+
+  void _onSliderChanged(int year) {
+    _controller.setYear(year);
+    _emitHaptics(year);
+  }
+
+  void _emitHaptics(int value) {
+    if (_lastHapticValue == value) return;
+    if (value % 100 == 0) {
+      HapticFeedback.heavyImpact();
+    } else if (value % 10 == 0) {
+      HapticFeedback.mediumImpact();
+    }
+    _lastHapticValue = value;
   }
 
   Future<void> _showResult() async {
-    final question = _questions[_currentQuestion];
-    final answer = _selectedYear.round();
-    final delta = (answer - question.answerYear).abs();
-    final isLast = _currentQuestion == _questions.length - 1;
+    final controller = _controller;
+    final stateBefore = _state;
+    final isLastQuestion =
+        stateBefore.currentIndex == stateBefore.questionCount - 1;
+    final result = controller.evaluate();
+    if (result == null) return;
 
-    final result = await showModalBottomSheet<bool>(
+    final proceed = await showModalBottomSheet<bool>(
       context: context,
       backgroundColor: AppColors.bgBase,
       isScrollControlled: true,
       builder: (context) => ResultSheet(
-        playerAnswer: answer,
-        correctAnswer: question.answerYear,
-        delta: delta,
-        points: (100 - delta).clamp(10, 100).toInt(),
-        isLast: isLast,
+        result: result,
+        isLast: isLastQuestion,
         onNext: () => Navigator.of(context).pop(true),
         onDetails: () => Navigator.of(context).pop(false),
       ),
     );
 
-    if (!mounted || result == null) return;
-
-    if (!result) {
+    if (!mounted) return;
+    if (proceed == false) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Экран с подробностями появится позже.')),
+        const SnackBar(
+          content: Text('Экран с подробностями появится позже.'),
+        ),
       );
-      return;
     }
 
-    if (isLast) {
-      context.go('/summary');
-      return;
+    final completed = controller.advance();
+    if (completed) {
+      final summary = controller.buildSummary();
+      context.go('/summary', extra: summary);
     }
+  }
 
-    setState(() {
-      _currentQuestion = (_currentQuestion + 1) % _questions.length;
-      _selectedYear = _questions[_currentQuestion].answerYear.toDouble();
-    });
+  void _useHint(HintType type) {
+    _controller.useHint(type);
   }
 
   @override
   Widget build(BuildContext context) {
-    final question = _questions[_currentQuestion];
-    final progress = (_currentQuestion + 1) / _questions.length;
+    final state = ref.watch(roundControllerProvider(widget.categoryId));
+
+    if (state.isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final question = state.currentQuestion;
+
+    if (question == null) {
+      return Scaffold(
+        appBar: AppTopBar(
+          title: const Text('Раунд'),
+          leading: IconButton(
+            onPressed: () => context.go('/home'),
+            icon: const Icon(Icons.close),
+          ),
+        ),
+        body: const Center(
+          child: Text('Нет доступных вопросов для этой категории.'),
+        ),
+      );
+    }
+
+    final progress = (state.currentIndex + 1) / state.questionCount;
+    final minYear = state.currentMinYear;
+    final maxYear = state.currentMaxYear;
+    final abOptions = state.abOptions;
+    final lastDigitsHint = state.lastDigitsHint;
+    final canSubmit = state.phase == RoundPhase.playing;
 
     return Scaffold(
       appBar: AppTopBar(
-        title: Text('${_currentQuestion + 1}/${_questions.length}'),
-        actions: const [
-          ResourceChip(icon: Icons.favorite, label: '5'),
-          ResourceChip(icon: Icons.flash_on, label: '120'),
-          ResourceChip(icon: Icons.ac_unit, label: '42'),
+        title: Text('${state.currentIndex + 1}/${state.questionCount}'),
+        actions: [
+          ResourceChip(icon: Icons.star, label: state.score.toString()),
+          ResourceChip(
+            icon: Icons.local_fire_department,
+            label: state.streak.toString(),
+          ),
+          ResourceChip(icon: Icons.favorite, label: state.lives.toString()),
         ],
       ),
       body: Column(
@@ -141,19 +158,29 @@ class _RoundScreenState extends State<RoundScreen> {
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        RichText(
+                        Text(
+                          question.prompt,
                           textAlign: TextAlign.center,
-                          text: TextSpan(
-                            style: AppTypography.h2Fact,
-                            children: [
-                              TextSpan(text: '${question.fact} '),
-                              TextSpan(
-                                text: question.highlight,
-                                style: AppTypography.h2FactEmphasis(context),
-                              ),
-                            ],
-                          ),
+                          style: AppTypography.h2Fact,
                         ),
+                        if (lastDigitsHint != null) ...[
+                          const SizedBox(height: AppSpacing.grid),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 8,
+                            ),
+                            decoration: BoxDecoration(
+                              color: AppColors.bgElevated,
+                              borderRadius: AppRadius.medium,
+                              border: Border.all(color: AppColors.accentSecondary),
+                            ),
+                            child: Text(
+                              lastDigitsHint,
+                              style: AppTypography.secondary,
+                            ),
+                          ),
+                        ],
                         const SizedBox(height: AppSpacing.grid * 2),
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,
@@ -161,36 +188,86 @@ class _RoundScreenState extends State<RoundScreen> {
                           children: [
                             _YearControlButton(
                               icon: Icons.remove,
-                              onPressed: () => _adjustYear(-1),
+                              onPressed: canSubmit
+                                  ? () => _adjustYear(-1)
+                                  : null,
                             ),
                             const SizedBox(width: AppSpacing.grid * 1.5),
                             Text(
-                              _selectedYear.round().toString(),
+                              state.selectedYear.toString(),
                               style: AppTypography.h1Year,
                             ),
                             const SizedBox(width: AppSpacing.grid * 1.5),
                             _YearControlButton(
                               icon: Icons.add,
-                              onPressed: () => _adjustYear(1),
+                              onPressed:
+                                  canSubmit ? () => _adjustYear(1) : null,
                             ),
                           ],
                         ),
                         const SizedBox(height: AppSpacing.grid * 1.5),
                         TimelineSlider(
-                          value: _selectedYear,
-                          onChanged: (value) => setState(() {
-                            _selectedYear = value;
-                          }),
+                          minYear: minYear,
+                          maxYear: maxYear,
+                          value: state.selectedYear,
+                          era: state.selectedEra,
+                          correctYear: question.correctYear,
+                          correctEra: question.era,
+                          onChanged: canSubmit ? _onSliderChanged : (_) {},
+                          onEraChanged:
+                              canSubmit ? (era) => _controller.setEra(era) : null,
                         ),
+                        if (abOptions != null) ...[
+                          const SizedBox(height: AppSpacing.grid * 1.5),
+                          Wrap(
+                            spacing: AppSpacing.grid,
+                            runSpacing: AppSpacing.grid,
+                            alignment: WrapAlignment.center,
+                            children: [
+                              for (final option in abOptions)
+                                ChoiceChip(
+                                  label: Text('$option ${state.selectedEra.label}'),
+                                  selected: state.selectedYear == option,
+                                  onSelected: canSubmit
+                                      ? (_) => _controller.setYear(option)
+                                      : null,
+                                ),
+                            ],
+                          ),
+                        ],
                         const SizedBox(height: AppSpacing.grid * 1.5),
                         Wrap(
                           spacing: AppSpacing.grid,
                           runSpacing: AppSpacing.grid,
                           alignment: WrapAlignment.center,
-                          children: const [
-                            HintButton(label: 'Last'),
-                            HintButton(label: 'A/B'),
-                            HintButton(label: 'Narrow'),
+                          children: [
+                            HintButton(
+                              label: 'Last (-50)',
+                              onPressed: canSubmit &&
+                                      !state.usedHints.contains(
+                                        HintType.lastDigits,
+                                      )
+                                  ? () => _useHint(HintType.lastDigits)
+                                  : null,
+                            ),
+                            HintButton(
+                              label: 'A/B (-100)',
+                              onPressed: canSubmit &&
+                                      !state.usedHints.contains(
+                                        HintType.abQuiz,
+                                      )
+                                  ? () => _useHint(HintType.abQuiz)
+                                  : null,
+                            ),
+                            HintButton(
+                              label: 'Narrow (-150)',
+                              onPressed: canSubmit &&
+                                      !state.usedHints.contains(
+                                        HintType.narrowTimeline,
+                                      )
+                                  ? () => _useHint(HintType.narrowTimeline)
+                                  : null,
+                            ),
                           ],
                         ),
                       ],
@@ -204,7 +281,7 @@ class _RoundScreenState extends State<RoundScreen> {
             minimum: const EdgeInsets.all(AppSpacing.screenPadding),
             child: PrimaryButton(
               label: 'Проверить дату',
-              onPressed: _showResult,
+              onPressed: canSubmit ? _showResult : null,
             ),
           ),
         ],
@@ -214,10 +291,10 @@ class _RoundScreenState extends State<RoundScreen> {
 }
 
 class _YearControlButton extends StatelessWidget {
-  const _YearControlButton({required this.icon, required this.onPressed});
+  const _YearControlButton({required this.icon, this.onPressed});
 
   final IconData icon;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -230,6 +307,7 @@ class _YearControlButton extends StatelessWidget {
           shape: const CircleBorder(),
           side: const BorderSide(color: AppColors.borderMuted),
           padding: EdgeInsets.zero,
+          disabledForegroundColor: AppColors.textSecondary,
         ),
         child: Icon(icon, color: AppColors.textPrimary),
       ),

--- a/lib/ui/screens/summary_screen.dart
+++ b/lib/ui/screens/summary_screen.dart
@@ -4,13 +4,28 @@ import 'package:go_router/go_router.dart';
 import '../components/app_top_bar.dart';
 import '../components/primary_button.dart';
 import '../components/secondary_text_button.dart';
+import '../state/round_controller.dart';
 import '../tokens.dart';
 
 class SummaryScreen extends StatelessWidget {
-  const SummaryScreen({super.key});
+  const SummaryScreen({super.key, this.summary});
+
+  final RoundSummary? summary;
 
   @override
   Widget build(BuildContext context) {
+    final data = summary;
+    final totalScore = data?.score ?? 0;
+    final averageDelta = data == null
+        ? '—'
+        : data.averageDelta.toStringAsFixed(1).replaceAll('.', ',');
+    final streak = data?.bestStreak ?? 0;
+    final closeHits = data?.closeHits ?? 0;
+    final totalQuestions = data?.totalQuestions ?? 0;
+    final accuracyText = totalQuestions == 0
+        ? '—'
+        : '$closeHits из $totalQuestions';
+
     return Scaffold(
       appBar: AppTopBar(
         leading: IconButton(
@@ -35,10 +50,10 @@ class SummaryScreen extends StatelessWidget {
               ),
             ),
             const SizedBox(height: AppSpacing.grid * 2),
-            const Text(
-              '1 250 очков',
+            Text(
+              '$totalScore очков',
               textAlign: TextAlign.center,
-              style: TextStyle(
+              style: const TextStyle(
                 fontSize: 32,
                 fontWeight: FontWeight.w700,
                 color: AppColors.accentPrimary,
@@ -54,17 +69,31 @@ class SummaryScreen extends StatelessWidget {
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                children: const [
-                  Text('Правильно: 7/10', style: AppTypography.secondary),
-                  SizedBox(height: 8),
-                  Text('Средняя дельта: 12 лет', style: AppTypography.secondary),
+                children: [
+                  Text(
+                    'Попадания ≤5 лет: $accuracyText',
+                    style: AppTypography.secondary,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Средняя дельта: $averageDelta',
+                    style: AppTypography.secondary,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Лучшая серия: $streak',
+                    style: AppTypography.secondary,
+                  ),
                 ],
               ),
             ),
             const Spacer(),
             PrimaryButton(
               label: 'Играть снова',
-              onPressed: () => context.go('/round/history'),
+              onPressed: () {
+                final category = summary?.categoryId ?? 'history';
+                context.go('/round/$category');
+              },
             ),
             const SizedBox(height: 8),
             SecondaryTextButton(

--- a/lib/ui/state/round_controller.dart
+++ b/lib/ui/state/round_controller.dart
@@ -1,0 +1,458 @@
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/question_repository.dart';
+import '../../models/question.dart';
+
+enum RoundPhase { loading, playing, reviewing, completed }
+
+enum HintType { lastDigits, abQuiz, narrowTimeline }
+
+class YearRange {
+  const YearRange(this.min, this.max);
+
+  final int min;
+  final int max;
+
+  int clamp(int value) {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  }
+}
+
+class QuestionResult {
+  QuestionResult({
+    required this.question,
+    required this.playerYear,
+    required this.playerEra,
+    required this.delta,
+    required this.baseScore,
+    required this.totalPoints,
+    required this.hintPenalty,
+    required this.netPoints,
+    required this.streakAfterAnswer,
+    required this.usedHints,
+    required this.streakBoostApplied,
+  });
+
+  final Question question;
+  final int playerYear;
+  final Era playerEra;
+  final int delta;
+  final int baseScore;
+  final int totalPoints;
+  final int hintPenalty;
+  final int netPoints;
+  final int streakAfterAnswer;
+  final Set<HintType> usedHints;
+  final bool streakBoostApplied;
+
+  bool get isPerfect => delta == 0;
+
+  bool get isCloseHit => delta <= 5;
+}
+
+class RoundSummary {
+  const RoundSummary({
+    required this.score,
+    required this.averageDelta,
+    required this.bestStreak,
+    required this.closeHits,
+    required this.totalQuestions,
+    required this.categoryId,
+  });
+
+  final int score;
+  final double averageDelta;
+  final int bestStreak;
+  final int closeHits;
+  final int totalQuestions;
+  final String categoryId;
+}
+
+@immutable
+class RoundState {
+  static const _sentinel = Object();
+
+  const RoundState({
+    this.phase = RoundPhase.loading,
+    this.questions = const [],
+    this.currentIndex = 0,
+    this.selectedYear = 0,
+    this.selectedEra = Era.ce,
+    this.score = 0,
+    this.lives = 3,
+    this.streak = 0,
+    this.bestStreak = 0,
+    this.usedHints = const {},
+    this.results = const [],
+    this.lastResult,
+    this.currentHintPenalty = 0,
+    this.narrowedRange,
+    this.abOptions,
+    this.lastDigitsHint,
+  });
+
+  final RoundPhase phase;
+  final List<Question> questions;
+  final int currentIndex;
+  final int selectedYear;
+  final Era selectedEra;
+  final int score;
+  final int lives;
+  final int streak;
+  final int bestStreak;
+  final Set<HintType> usedHints;
+  final List<QuestionResult> results;
+  final QuestionResult? lastResult;
+  final int currentHintPenalty;
+  final YearRange? narrowedRange;
+  final List<int>? abOptions;
+  final String? lastDigitsHint;
+
+  bool get isLoading => phase == RoundPhase.loading;
+
+  bool get isReviewing => phase == RoundPhase.reviewing;
+
+  bool get isCompleted => phase == RoundPhase.completed;
+
+  Question? get currentQuestion =>
+      questions.isEmpty ? null : questions[currentIndex];
+
+  int get questionCount => questions.length;
+
+  int get currentMinYear => narrowedRange?.min ?? currentQuestion?.minYear ?? 0;
+
+  int get currentMaxYear => narrowedRange?.max ?? currentQuestion?.maxYear ?? 0;
+
+  RoundState copyWith({
+    RoundPhase? phase,
+    List<Question>? questions,
+    int? currentIndex,
+    int? selectedYear,
+    Era? selectedEra,
+    int? score,
+    int? lives,
+    int? streak,
+    int? bestStreak,
+    Set<HintType>? usedHints,
+    List<QuestionResult>? results,
+    Object? lastResult = _sentinel,
+    int? currentHintPenalty,
+    Object? narrowedRange = _sentinel,
+    Object? abOptions = _sentinel,
+    Object? lastDigitsHint = _sentinel,
+  }) {
+    return RoundState(
+      phase: phase ?? this.phase,
+      questions: questions ?? this.questions,
+      currentIndex: currentIndex ?? this.currentIndex,
+      selectedYear: selectedYear ?? this.selectedYear,
+      selectedEra: selectedEra ?? this.selectedEra,
+      score: score ?? this.score,
+      lives: lives ?? this.lives,
+      streak: streak ?? this.streak,
+      bestStreak: bestStreak ?? this.bestStreak,
+      usedHints: usedHints ?? this.usedHints,
+      results: results ?? this.results,
+      lastResult: identical(lastResult, _sentinel)
+          ? this.lastResult
+          : lastResult as QuestionResult?,
+      currentHintPenalty: currentHintPenalty ?? this.currentHintPenalty,
+      narrowedRange: identical(narrowedRange, _sentinel)
+          ? this.narrowedRange
+          : narrowedRange as YearRange?,
+      abOptions: identical(abOptions, _sentinel)
+          ? this.abOptions
+          : abOptions as List<int>?,
+      lastDigitsHint: identical(lastDigitsHint, _sentinel)
+          ? this.lastDigitsHint
+          : lastDigitsHint as String?,
+    );
+  }
+}
+
+class RoundController extends StateNotifier<RoundState> {
+  RoundController({
+    required this.categoryId,
+    required this.repository,
+  }) : super(const RoundState());
+
+  final String categoryId;
+  final QuestionRepository repository;
+
+  bool _initialized = false;
+
+  Future<void> ensureLoaded() async {
+    if (_initialized) return;
+    _initialized = true;
+    await load();
+  }
+
+  Future<void> load() async {
+    state = state.copyWith(phase: RoundPhase.loading);
+    final questions = await repository.loadByCategory(categoryId);
+    if (questions.isEmpty) {
+      state = state.copyWith(
+        phase: RoundPhase.completed,
+        questions: const [],
+        score: 0,
+        streak: 0,
+        bestStreak: 0,
+        results: const [],
+      );
+      return;
+    }
+    final first = questions.first;
+    state = RoundState(
+      phase: RoundPhase.playing,
+      questions: questions,
+      currentIndex: 0,
+      selectedYear: first.defaultYear,
+      selectedEra: first.era,
+      score: 0,
+      lives: state.lives,
+      streak: 0,
+      bestStreak: 0,
+      usedHints: const <HintType>{},
+      results: const [],
+      currentHintPenalty: 0,
+      narrowedRange: null,
+      abOptions: null,
+      lastDigitsHint: null,
+    );
+  }
+
+  void adjustYear(int delta) {
+    final question = state.currentQuestion;
+    if (state.phase != RoundPhase.playing || question == null) return;
+    final minYear = state.currentMinYear;
+    final maxYear = state.currentMaxYear;
+    final newYear = _clampInt(state.selectedYear + delta, minYear, maxYear);
+    state = state.copyWith(selectedYear: newYear);
+  }
+
+  void setYear(int year) {
+    final question = state.currentQuestion;
+    if (state.phase != RoundPhase.playing || question == null) return;
+    final minYear = state.currentMinYear;
+    final maxYear = state.currentMaxYear;
+    final clamped = _clampInt(year, minYear, maxYear);
+    state = state.copyWith(selectedYear: clamped);
+  }
+
+  void setEra(Era era) {
+    if (state.phase != RoundPhase.playing) return;
+    state = state.copyWith(selectedEra: era);
+  }
+
+  void useHint(HintType type) {
+    final question = state.currentQuestion;
+    if (question == null || state.phase != RoundPhase.playing) return;
+    if (state.usedHints.contains(type)) return;
+
+    final newUsed = {...state.usedHints, type};
+    var penalty = state.currentHintPenalty;
+    YearRange? newRange = state.narrowedRange;
+    List<int>? abOptions = state.abOptions;
+    String? lastDigitsHint = state.lastDigitsHint;
+    var selectedYear = state.selectedYear;
+
+    switch (type) {
+      case HintType.lastDigits:
+        final digits = question.correctYear % 100;
+        final formatted = digits.toString().padLeft(2, '0');
+        lastDigitsHint = 'Год заканчивается на $formatted';
+        penalty += 50;
+        break;
+      case HintType.abQuiz:
+        final options = _buildAbOptions(question);
+        abOptions = options;
+        penalty += 100;
+        break;
+      case HintType.narrowTimeline:
+        newRange = _buildNarrowRange(question);
+        selectedYear = newRange.clamp(selectedYear);
+        penalty += 150;
+        break;
+    }
+
+    state = state.copyWith(
+      usedHints: Set<HintType>.unmodifiable(newUsed),
+      currentHintPenalty: penalty,
+      narrowedRange: newRange,
+      abOptions: abOptions,
+      lastDigitsHint: lastDigitsHint,
+      selectedYear: selectedYear,
+    );
+  }
+
+  List<int> _buildAbOptions(Question question) {
+    final random = Random(question.id.hashCode);
+    final offset = max(2, min(80, question.range ~/ 4));
+    final delta = random.nextInt(offset) + 1;
+    final altValue = (random.nextBool()
+            ? question.correctYear + delta
+            : question.correctYear - delta)
+        .clamp(question.minYear, question.maxYear);
+    final alt = altValue is double ? altValue.round() : altValue as int;
+    final options = <int>{question.correctYear, alt}.toList();
+    options.shuffle(random);
+    return options;
+  }
+
+  YearRange _buildNarrowRange(Question question) {
+    final span = max(1, question.range);
+    final narrowSpan = max(5, (span * 0.2).round());
+    final half = narrowSpan ~/ 2;
+    var minYear = question.correctYear - half;
+    var maxYear = question.correctYear + (narrowSpan - half);
+    if (minYear < question.minYear) {
+      maxYear += question.minYear - minYear;
+      minYear = question.minYear;
+    }
+    if (maxYear > question.maxYear) {
+      minYear -= maxYear - question.maxYear;
+      maxYear = question.maxYear;
+    }
+    minYear = _clampInt(minYear, question.minYear, question.maxYear);
+    maxYear = _clampInt(maxYear, question.minYear, question.maxYear);
+    if (minYear == maxYear) {
+      maxYear = min(maxYear + 1, question.maxYear);
+    }
+    return YearRange(minYear, maxYear);
+  }
+
+  int _clampInt(int value, int minValue, int maxValue) {
+    if (value < minValue) return minValue;
+    if (value > maxValue) return maxValue;
+    return value;
+  }
+
+  QuestionResult? evaluate() {
+    final question = state.currentQuestion;
+    if (question == null || state.phase != RoundPhase.playing) {
+      return null;
+    }
+    final playerYear = state.selectedYear;
+    final playerEra = state.selectedEra;
+    final playerSigned = playerEra.signedYear(playerYear);
+    final correctSigned = question.era.signedYear(question.correctYear);
+    final delta = (playerSigned - correctSigned).abs();
+    final baseScore = max(0, 1000 - delta * 2);
+    var bonus = 0;
+    if (delta <= 1) {
+      bonus += 200;
+    } else if (delta <= 5) {
+      bonus += 100;
+    }
+    var streak = delta <= 5 ? state.streak + 1 : 0;
+    var streakBoostApplied = false;
+    var multiplier = 1.0;
+    if (streak >= 3) {
+      multiplier *= 1.5;
+      streakBoostApplied = true;
+    }
+    final totalPoints = ((baseScore + bonus) * multiplier).round();
+    final netPoints = totalPoints - state.currentHintPenalty;
+    final bestStreak = max(state.bestStreak, streak);
+
+    final result = QuestionResult(
+      question: question,
+      playerYear: playerYear,
+      playerEra: playerEra,
+      delta: delta,
+      baseScore: baseScore,
+      totalPoints: totalPoints,
+      hintPenalty: state.currentHintPenalty,
+      netPoints: netPoints,
+      streakAfterAnswer: streak,
+      usedHints: Set<HintType>.unmodifiable(state.usedHints),
+      streakBoostApplied: streakBoostApplied,
+    );
+
+    final updatedResults = [...state.results, result];
+
+    state = state.copyWith(
+      score: state.score + netPoints,
+      streak: streak,
+      bestStreak: bestStreak,
+      phase: RoundPhase.reviewing,
+      lastResult: result,
+      results: updatedResults,
+      currentHintPenalty: 0,
+    );
+
+    return result;
+  }
+
+  bool advance() {
+    if (state.phase != RoundPhase.reviewing) {
+      return false;
+    }
+    final isLast = state.currentIndex >= state.questions.length - 1;
+    if (isLast) {
+      state = state.copyWith(phase: RoundPhase.completed);
+      return true;
+    }
+    final nextIndex = state.currentIndex + 1;
+    final nextQuestion = state.questions[nextIndex];
+    state = state.copyWith(
+      phase: RoundPhase.playing,
+      currentIndex: nextIndex,
+      selectedYear: nextQuestion.defaultYear,
+      selectedEra: nextQuestion.era,
+      usedHints: const <HintType>{},
+      narrowedRange: null,
+      abOptions: null,
+      lastDigitsHint: null,
+      lastResult: null,
+      currentHintPenalty: 0,
+    );
+    return false;
+  }
+
+  RoundSummary? buildSummary() {
+    if (state.results.isEmpty) {
+      return null;
+    }
+    final totalDelta =
+        state.results.fold<int>(0, (sum, result) => sum + result.delta);
+    final average = totalDelta / state.results.length;
+    final closeHits =
+        state.results.where((result) => result.delta <= 5).length;
+    return RoundSummary(
+      score: state.score,
+      averageDelta: average,
+      bestStreak: state.bestStreak,
+      closeHits: closeHits,
+      totalQuestions: state.results.length,
+      categoryId: categoryId,
+    );
+  }
+
+  void resetForReplay() {
+    _initialized = false;
+  }
+}
+
+final questionRepositoryProvider = Provider<QuestionRepository>((ref) {
+  return QuestionRepository();
+});
+
+final roundControllerProvider =
+    StateNotifierProvider.autoDispose.family<RoundController, RoundState, String>(
+  (ref, categoryId) {
+    final repository = ref.watch(questionRepositoryProvider);
+    final controller = RoundController(
+      categoryId: categoryId,
+      repository: repository,
+    );
+    ref.onDispose(controller.resetForReplay);
+    controller.ensureLoaded();
+    return controller;
+  },
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   go_router: ^14.1.4
+  flutter_riverpod: ^2.5.1
 
 dev_dependencies:
   flutter_test:
@@ -16,3 +17,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/questions.json


### PR DESCRIPTION
## Summary
- load round questions from a new JSON asset and manage gameplay with a Riverpod state notifier
- update the round UI to support hints, scoring, enhanced timeline slider feedback, and modal results
- refresh the summary screen and result sheet to display computed stats and integrate the new scoring model

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9a15d222883269e99b634c92db626