### PR TITLE
fix(deps): replace lucide_icons with lucide_flutter and update dependencies

### DIFF
--- a/lib/ui/components/card_tile.dart
+++ b/lib/ui/components/card_tile.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_flutter/lucide_flutter.dart';
 
 import '../tokens.dart';
 

--- a/lib/ui/components/empty_error_state.dart
+++ b/lib/ui/components/empty_error_state.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_flutter/lucide_flutter.dart';
 
 import '../tokens.dart';
 

--- a/lib/ui/components/locale_menu.dart
+++ b/lib/ui/components/locale_menu.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_flutter/lucide_flutter.dart';
 
 import '../state/locale_controller.dart';
 import '../tokens.dart';

--- a/lib/ui/screens/categories_screen.dart
+++ b/lib/ui/screens/categories_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_flutter/lucide_flutter.dart';
 
 import '../../features/modes/game_mode.dart';
 import '../../features/modes/mode_controller.dart';

--- a/lib/ui/screens/round_screen.dart
+++ b/lib/ui/screens/round_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_flutter/lucide_flutter.dart';
 
 import '../../content/models.dart';
 import '../../features/modes/game_mode.dart';

--- a/lib/ui/screens/stub_screen.dart
+++ b/lib/ui/screens/stub_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_flutter/lucide_flutter.dart';
 
 import '../components/app_top_bar.dart';
 import '../components/locale_menu.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  go_router: ^14.1.4
-  flutter_riverpod: ^2.5.1
+  go_router: ^16.2.4
+  flutter_riverpod: ^3.0.0
   flutter_localizations:
     sdk: flutter
-  intl: ^0.19.0
+  intl: ^0.20.2
   csv: ^5.0.2
-  lucide_icons: ^0.322.0
+  lucide_flutter: ^0.352.0
   shimmer: ^3.0.0
   firebase_core: ^2.31.1
   firebase_analytics: ^10.10.7
@@ -29,3 +29,4 @@ flutter:
   uses-material-design: true
   assets:
     - assets/data/
+    - assets/events/


### PR DESCRIPTION
## Summary
- replace the deprecated `lucide_icons` dependency with `lucide_flutter` and update all call sites
- bump routing, state management, and localization dependencies to their current compatible versions and keep shimmer pinned
- ensure the Flutter asset list includes the events directory required by the app

## Testing
- Flutter tooling unavailable in container (`flutter pub get`)


------
https://chatgpt.com/codex/tasks/task_e_68d9c38ffba48326963345334ee8ae02