### PR TITLE
Migrate Android Gradle setup to Flutter plugin DSL

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,57 +1,37 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
-}
-
-import java.util.Properties
-
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file("local.properties")
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withInputStream { localProperties.load(it) }
-}
-
-def flutterRoot = localProperties.getProperty("flutter.sdk")
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define flutter.sdk in the local.properties file.")
-}
-
-def flutterVersionCode = localProperties.getProperty("flutter.versionCode") ?: "1"
-def flutterVersionName = localProperties.getProperty("flutter.versionName") ?: "1.0"
-
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
-flutter {
-    source '../..'
+    id "org.jetbrains.kotlin.android"
+    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    id "dev.flutter.flutter-gradle-plugin"
 }
 
 android {
     namespace "com.example.datag"
-    compileSdkVersion 36
+    compileSdk = 36
 
     defaultConfig {
         applicationId "com.example.datag"
-        minSdkVersion 23
-        targetSdkVersion 36
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk = 23
+        targetSdk = 36
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
         multiDexEnabled true
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     buildTypes {
         release {
-            minifyEnabled false
-            shrinkResources false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            isMinifyEnabled = false
+            isShrinkResources = false
+            proguardFiles(getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro')
         }
     }
 }
@@ -59,4 +39,8 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.25"
     implementation "androidx.multidex:multidex:2.0.1"
+}
+
+flutter {
+    source = "../.."
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:8.5.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25"
-    }
-}
-
 allprojects {
     repositories {
         google()
@@ -16,11 +5,16 @@ allprojects {
     }
 }
 
-def newBuildDir = rootProject.layout.buildDirectory.dir("../../build")
-rootProject.layout.buildDirectory.set(newBuildDir)
+def newBuildDir = rootProject.layout.buildDirectory.dir("../../build").get()
+rootProject.layout.buildDirectory.value(newBuildDir)
 
 subprojects { project ->
-    project.layout.buildDirectory.set(newBuildDir.map { it.dir(project.name) })
+    def newSubprojectBuildDir = newBuildDir.dir(project.name)
+    project.layout.buildDirectory.value(newSubprojectBuildDir)
+}
+
+subprojects {
+    project.evaluationDependsOn(":app")
 }
 
 tasks.register("clean", Delete) {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,17 +1,32 @@
 import java.util.Properties
 
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        def localPropertiesFile = file("local.properties")
+        if (localPropertiesFile.exists()) {
+            localPropertiesFile.withInputStream { properties.load(it) }
+        }
+        def flutterSdk = properties.getProperty('flutter.sdk')
+        if (flutterSdk == null) {
+            throw new GradleException("Flutter SDK not found. Define flutter.sdk in the local.properties file.")
+        }
+        return flutterSdk
+    }.call()
+
+    includeBuild("${flutterSdkPath}/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.5.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.25" apply false
+}
+
 include ':app'
-
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
-
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withInputStream { properties.load(it) }
-}
-
-def flutterSdkPath = properties.getProperty('flutter.sdk')
-if (flutterSdkPath == null) {
-    throw new GradleException("Flutter SDK not found. Define flutter.sdk in the local.properties file.")
-}
-
-apply from: "${flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"


### PR DESCRIPTION
## Summary
- migrate the Android Gradle configuration to use Flutter's new plugin DSL
- update the app module build script to rely on the Flutter Gradle plugin while keeping existing SDK and build settings
- adjust the root Gradle scripts to align with the plugin-based configuration and shared build directory setup

## Testing
- not run (Android toolchain and Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da46f873dc8326b52f19faecaf8ebd