### PR TITLE
Fix Android build configs for AGP 8+

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,15 +29,19 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
-            isShrinkResources = false
+            minifyEnabled false
+            shrinkResources false
             proguardFiles(getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro')
+        }
+        debug {
+            debuggable true
+            minifyEnabled false
         }
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.25"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:2.1.0"
     implementation "androidx.multidex:multidex:2.0.1"
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id "com.android.application" version "8.6.0" apply false
+    id "com.android.library" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+}
+
 allprojects {
     repositories {
         google()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip


### PR DESCRIPTION
## Summary
- replace deprecated `isMinifyEnabled`/`isShrinkResources` buildType flags with the AGP 8 syntax and add an explicit debug build type
- raise the Android/Kotlin Gradle plugin versions to 8.6.0/2.1.0 and match the Kotlin stdlib dependency
- update the Gradle wrapper to 8.9 to align with the newer toolchain

## Testing
- `flutter pub get` *(fails: `flutter` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da49758bcc83268adcab2e108205e9