### PR TITLE
Update Android SDK levels to API 34

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace "com.example.datag"
-    compileSdk = 36
+    compileSdk = 34
 
     defaultConfig {
         applicationId "com.example.datag"
         minSdk = 23
-        targetSdk = 36
+        targetSdk = 34
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         multiDexEnabled true


### PR DESCRIPTION
## Summary
- update the Android app module to target the installed stable API level 34

## Testing
- gradle assembleDebug *(fails: Flutter SDK not found in local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68da4e2aa8748326a3412baf36d243b2