### PR TITLE
Ensure summary screen navigation uses null-safe summary data

### DIFF
--- a/lib/ui/screens/summary_screen.dart
+++ b/lib/ui/screens/summary_screen.dart
@@ -23,15 +23,16 @@ class SummaryScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context)!;
-    final data = completion?.summary;
-    final totalScore = data?.score ?? 0;
+    final summary = completion?.summary;
+    final dailyLeaderboard = completion?.dailyLeaderboard;
+    final totalScore = summary?.score ?? 0;
     final locale = Localizations.localeOf(context);
-    final averageDelta = data == null
+    final averageDelta = summary == null
         ? l.summaryNoValue
-        : NumberFormat('0.0', locale.toLanguageTag()).format(data.averageDelta);
-    final streak = data?.bestStreak ?? 0;
-    final closeHits = data?.closeHits ?? 0;
-    final totalQuestions = data?.totalQuestions ?? 0;
+        : NumberFormat('0.0', locale.toLanguageTag()).format(summary.averageDelta);
+    final streak = summary?.bestStreak ?? 0;
+    final closeHits = summary?.closeHits ?? 0;
+    final totalQuestions = summary?.totalQuestions ?? 0;
     final accuracyText = totalQuestions == 0
         ? l.summaryNoValue
         : l.summaryAccuracyValue(closeHits, totalQuestions);
@@ -95,10 +96,10 @@ class SummaryScreen extends StatelessWidget {
                     l.summaryBestStreak(streak),
                     style: AppTypography.secondary,
                   ),
-                  if (data != null) ...[
+                  if (summary != null) ...[
                     const SizedBox(height: 8),
                     Text(
-                      'Time bonus: ${data.timeBonusTotal}',
+                      'Time bonus: ${summary.timeBonusTotal}',
                       style: AppTypography.secondary,
                     ),
                   ],
@@ -108,19 +109,20 @@ class SummaryScreen extends StatelessWidget {
             const Spacer(),
             if (completion?.duelReport != null)
               _DuelResultCard(report: completion!.duelReport!),
-            if (completion?.dailyLeaderboard != null &&
-                completion!.dailyLeaderboard!.isNotEmpty)
+            if (summary != null &&
+                dailyLeaderboard != null &&
+                dailyLeaderboard.isNotEmpty)
               _DailyLeaderboardCard(
-                leaderboard: completion!.dailyLeaderboard!,
-                current: completion!.summary,
+                leaderboard: dailyLeaderboard,
+                current: summary,
               ),
             const SizedBox(height: AppSpacing.grid * 2),
             PrimaryButton(
               label: l.summaryPlayAgain,
               onPressed: () {
-                final category = completion?.summary.categoryId ?? 'history';
-                final mode = completion?.summary.modeId ?? GameModeId.classic10;
-                context.go('/round/$category?mode=${mode.key}');
+                final categoryId = summary?.categoryId ?? 'history';
+                final modeId = summary?.modeId ?? GameModeId.classic10;
+                context.go('/round/$categoryId?mode=${modeId.key}');
               },
             ),
             const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- capture the round summary before building the widget tree
- guard leaderboard rendering against null summary data
- default to history/classic10 when summary metadata is missing

## Testing
- dart analyze *(fails: `dart` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da4e2f7ed48326aab46e2a2599c883