### PR TITLE
Fix localization references and cleanup imports

### DIFF
--- a/lib/content/models.dart
+++ b/lib/content/models.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
-import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
 
 enum Era { bce, ce }
 

--- a/lib/ui/tokens.dart
+++ b/lib/ui/tokens.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 
 /// Centralized design tokens for the dark MVP theme described in the


### PR DESCRIPTION
## Summary
- replace the direct `dart:ui` dependency in the content models with Flutter's widgets import for Locale support
- remove the redundant `dart:ui` import from the shared token definitions since material already re-exports the required symbols

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da5fd5a9f883269c500c44d7249b78