### PR TITLE
Configure localization generation and update hint entries

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,5 @@
+arb-dir: l10n
+template-arb-file: app_en.arb
+output-class: AppLocalizations
+output-localization-file: app_localizations.dart
+synthetic-package: true

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -5,9 +5,30 @@
   "roundDetailsComingSoon": "More details coming soon.",
   "roundNoQuestions": "No questions available yet.",
   "roundSubmit": "Submit answer",
-  "roundHintAB": "50/50",
-  "roundHintLast": "Last digits",
-  "roundHintNarrow": "Narrow timeline",
+  "roundHintAB": "50/50 (−{cost})",
+  "@roundHintAB": {
+    "placeholders": {
+      "cost": {
+        "type": "int"
+      }
+    }
+  },
+  "roundHintLast": "Last digits (−{cost})",
+  "@roundHintLast": {
+    "placeholders": {
+      "cost": {
+        "type": "int"
+      }
+    }
+  },
+  "roundHintNarrow": "Narrow timeline (−{cost})",
+  "@roundHintNarrow": {
+    "placeholders": {
+      "cost": {
+        "type": "int"
+      }
+    }
+  },
   "roundLastDigitsHint": "Last digits: {digits}",
   "@roundLastDigitsHint": {
     "placeholders": {
@@ -159,6 +180,9 @@
   "summaryPlayAgain": "Play again",
   "summaryHome": "Back to home",
   "summaryNoValue": "—",
+  "hintLabelLastDigits": "Last digits",
+  "hintLabelAB": "50/50",
+  "hintLabelNarrow": "Narrow timeline",
   "stubComingSoon": "\"{title}\" is coming soon!",
   "@stubComingSoon": {
     "placeholders": {

--- a/l10n/app_ru.arb
+++ b/l10n/app_ru.arb
@@ -5,9 +5,30 @@
   "roundDetailsComingSoon": "Скоро появятся подробности.",
   "roundNoQuestions": "Вопросов пока нет.",
   "roundSubmit": "Ответить",
-  "roundHintAB": "50/50",
-  "roundHintLast": "Последние цифры",
-  "roundHintNarrow": "Сузить шкалу",
+  "roundHintAB": "50/50 (−{cost})",
+  "@roundHintAB": {
+    "placeholders": {
+      "cost": {
+        "type": "int"
+      }
+    }
+  },
+  "roundHintLast": "Последние цифры (−{cost})",
+  "@roundHintLast": {
+    "placeholders": {
+      "cost": {
+        "type": "int"
+      }
+    }
+  },
+  "roundHintNarrow": "Сузить шкалу (−{cost})",
+  "@roundHintNarrow": {
+    "placeholders": {
+      "cost": {
+        "type": "int"
+      }
+    }
+  },
   "roundLastDigitsHint": "Последние цифры: {digits}",
   "@roundLastDigitsHint": {
     "placeholders": {
@@ -159,6 +180,9 @@
   "summaryPlayAgain": "Сыграть ещё",
   "summaryHome": "На главный экран",
   "summaryNoValue": "—",
+  "hintLabelLastDigits": "Последние цифры",
+  "hintLabelAB": "50/50",
+  "hintLabelNarrow": "Сузить шкалу",
   "stubComingSoon": "Раздел «{title}» скоро появится!",
   "@stubComingSoon": {
     "placeholders": {


### PR DESCRIPTION
## Summary
- add l10n.yaml to configure flutter gen-l10n for AppLocalizations
- extend both English and Russian ARB files with hint button labels and cost placeholders

## Testing
- not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68da635d72c48326aa4a2a726da827e2