### PR TITLE
Fix localization placeholder type for Ukrainian digits hint

### DIFF
--- a/l10n/app_uk.arb
+++ b/l10n/app_uk.arb
@@ -42,7 +42,7 @@
   "@roundLastDigitsHint": {
     "placeholders": {
       "digits": {
-        "type": "String"
+        "type": "Object"
       }
     }
   },


### PR DESCRIPTION
## Summary
- align the Ukrainian `roundLastDigitsHint` placeholder type with the template so gen_l10n can run without errors

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da6878dedc832699cd9827f310d167