### PR TITLE
Fix Flutter binding initialization zone mismatch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,9 +7,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app.dart';
 
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-
   await runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+
     runApp(const ProviderScope(child: DataGApp()));
   }, (error, stack) {
     if (kDebugMode) {


### PR DESCRIPTION
## Summary
- initialize Flutter bindings within the same zone as runApp to avoid zone mismatch errors

## Testing
- not run (Flutter CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da6f8dcf148326ac131c46cbb983fd