### PR TITLE
Implement animated mobile home and categories experiences

### DIFF
--- a/assets/data/categories.json
+++ b/assets/data/categories.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "history",
+    "titleKey": "cat_history",
+    "colorKey": "history",
+    "iconKey": "bank",
+    "progress": 0.42,
+    "locked": false
+  },
+  {
+    "id": "sport",
+    "titleKey": "cat_sport",
+    "colorKey": "sport",
+    "iconKey": "basketball",
+    "progress": 0.18,
+    "locked": false
+  },
+  {
+    "id": "movies",
+    "titleKey": "cat_movies",
+    "colorKey": "movies",
+    "iconKey": "movie",
+    "progress": 0.27,
+    "locked": false
+  },
+  {
+    "id": "art",
+    "titleKey": "cat_art",
+    "colorKey": "art",
+    "iconKey": "palette",
+    "progress": 0.36,
+    "locked": false
+  },
+  {
+    "id": "games",
+    "titleKey": "cat_games",
+    "colorKey": "games",
+    "iconKey": "gamepad",
+    "progress": 0.12,
+    "locked": false
+  },
+  {
+    "id": "books",
+    "titleKey": "cat_books",
+    "colorKey": "books",
+    "iconKey": "book",
+    "progress": 0.58,
+    "locked": false
+  },
+  {
+    "id": "world",
+    "titleKey": "cat_world",
+    "colorKey": "world",
+    "iconKey": "public",
+    "progress": 0.21,
+    "locked": false
+  }
+]

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,6 +8,7 @@ import 'analytics/dev_diagnostics.dart';
 import 'ui/screens/categories_screen.dart';
 import 'ui/screens/home_screen.dart';
 import 'ui/screens/round_screen.dart';
+import 'ui/screens/stub_screen.dart';
 import 'ui/state/locale_controller.dart';
 import 'ui/state/strings.dart';
 import 'ui/theme/app_theme.dart';
@@ -43,10 +44,27 @@ class _DataGAppState extends ConsumerState<DataGApp> {
           ),
         ),
         GoRoute(
+          path: '/stub',
+          pageBuilder: (context, state) {
+            final title = state.uri.queryParameters['title'] ?? strings.appTitle;
+            return _buildPage(
+              state,
+              StubScreen(title: title),
+            );
+          },
+        ),
+        GoRoute(
           path: '/categories',
           pageBuilder: (context, state) => _buildPage(
             state,
             const CategoriesScreen(),
+          ),
+        ),
+        GoRoute(
+          path: '/round',
+          pageBuilder: (context, state) => _buildPage(
+            state,
+            const RoundEntryScreen(),
           ),
         ),
         GoRoute(

--- a/lib/ui/screens/round_screen.dart
+++ b/lib/ui/screens/round_screen.dart
@@ -6,6 +6,7 @@ import '../components/app_button.dart';
 import '../components/app_card.dart';
 import '../components/app_scaffold.dart';
 import '../components/app_top_bar.dart';
+import '../components/app_badge.dart';
 import '../state/category_selection.dart';
 import '../state/player_resources.dart';
 import '../state/strings.dart';
@@ -19,53 +20,122 @@ class RoundScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final strings = ref.watch(stringsProvider);
-    final category = AppCategories.byId(categoryId);
+    final categoriesAsync = ref.watch(categoryListProvider);
 
-    return AppScaffold(
-      topBar: AppTopBar(
-        title: strings.roundPlaceholderTitle,
-        subtitle: strings.roundPlaceholderSubtitle,
-        onMenuTap: () => context.pop(),
+    return categoriesAsync.when(
+      loading: () => AppScaffold(
+        topBar: AppTopBar(
+          title: strings.roundPlaceholderTitle,
+          subtitle: strings.roundPlaceholderSubtitle,
+          onMenuTap: () => context.pop(),
+        ),
+        body: const Center(child: CircularProgressIndicator()),
       ),
-      body: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 420),
-          child: AppCard(
-            variant: AppCardVariant.elevated,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Category', style: AppTypography.caption.copyWith(color: AppColors.textMuted)),
-                const SizedBox(height: AppSpacing.xs),
-                Text(category.label, style: AppTypography.h2),
-                const SizedBox(height: AppSpacing.xl),
-                Text(
-                  'This is a premium visual placeholder for the upcoming gameplay loop. '
-                  'Use the buttons below to simulate resource flow.',
-                  style: AppTypography.body,
-                ),
-                const SizedBox(height: AppSpacing.xxl),
-                AppButton(
-                  label: 'Spend 1 life & 20 gems',
-                  variant: AppButtonVariant.secondary,
-                  onPressed: () {
-                    ref.read(playerResourcesProvider.notifier).spend(lives: 1, gems: 20);
-                  },
-                ),
-                const SizedBox(height: AppSpacing.md),
-                AppButton(
-                  label: 'Gain XP boost',
-                  icon: Icons.trending_up,
-                  onPressed: () {
-                    ref.read(playerResourcesProvider.notifier).gain(xp: 500, energy: 3);
-                  },
-                ),
-              ],
-            ),
+      error: (error, stackTrace) => AppScaffold(
+        topBar: AppTopBar(
+          title: strings.roundPlaceholderTitle,
+          subtitle: strings.roundPlaceholderSubtitle,
+          onMenuTap: () => context.pop(),
+        ),
+        body: Center(
+          child: Text(
+            'Failed to load category',
+            style: AppTypography.body,
+            textAlign: TextAlign.center,
           ),
         ),
       ),
+      data: (categories) {
+        final category = categories.firstWhere(
+          (definition) => definition.id == categoryId,
+          orElse: () => categories.isEmpty
+              ? CategoryDefinition(
+                  id: 'unknown',
+                  titleKey: 'cat_history',
+                  colorKey: 'history',
+                  iconKey: 'bank',
+                  progress: 0,
+                  locked: false,
+                )
+              : categories.first,
+        );
+        final title = category.localizedTitle(strings);
+
+        return AppScaffold(
+          topBar: AppTopBar(
+            title: strings.roundPlaceholderTitle,
+            subtitle: strings.roundPlaceholderSubtitle,
+            onMenuTap: () => context.pop(),
+          ),
+          body: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: AppCard(
+                variant: AppCardVariant.elevated,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Category',
+                        style: AppTypography.caption
+                            .copyWith(color: AppColors.textMuted)),
+                    const SizedBox(height: AppSpacing.xs),
+                    Row(
+                      children: [
+                        AppBadge(
+                          label: title,
+                          color: category.accentColor,
+                        ),
+                        const Spacer(),
+                        Icon(
+                          category.iconData,
+                          color: category.accentColor,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: AppSpacing.xl),
+                    Text(
+                      'This is a premium visual placeholder for the upcoming gameplay loop. '
+                      'Use the buttons below to simulate resource flow.',
+                      style: AppTypography.body,
+                    ),
+                    const SizedBox(height: AppSpacing.xxl),
+                    AppButton(
+                      label: 'Spend 1 life & 20 gems',
+                      variant: AppButtonVariant.secondary,
+                      onPressed: () {
+                        ref
+                            .read(playerResourcesProvider.notifier)
+                            .spend(lives: 1, gems: 20);
+                      },
+                    ),
+                    const SizedBox(height: AppSpacing.md),
+                    AppButton(
+                      label: 'Gain XP boost',
+                      icon: Icons.trending_up,
+                      onPressed: () {
+                        ref
+                            .read(playerResourcesProvider.notifier)
+                            .gain(xp: 500, energy: 3);
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
+  }
+}
+
+class RoundEntryScreen extends ConsumerWidget {
+  const RoundEntryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selected = ref.watch(selectedCategoryProvider);
+    return RoundScreen(categoryId: selected);
   }
 }

--- a/lib/ui/screens/stub_screen.dart
+++ b/lib/ui/screens/stub_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../components/app_button.dart';
+import '../components/app_card.dart';
+import '../components/app_scaffold.dart';
+import '../components/app_top_bar.dart';
+import '../state/strings.dart';
+import '../theme/tokens.dart';
+
+class StubScreen extends ConsumerWidget {
+  const StubScreen({super.key, required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final strings = ref.watch(stringsProvider);
+
+    return AppScaffold(
+      topBar: AppTopBar(
+        title: title,
+        subtitle: strings.roundPlaceholderSubtitle,
+        onMenuTap: () => context.go('/home'),
+      ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: AppCard(
+            variant: AppCardVariant.outlined,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  strings.roundPlaceholderTitle,
+                  style: AppTypography.h2,
+                ),
+                const SizedBox(height: AppSpacing.md),
+                Text(
+                  'Premium mode preview. Gameplay modules will arrive shortly.',
+                  style: AppTypography.body,
+                ),
+                const SizedBox(height: AppSpacing.xxl),
+                AppButton(
+                  label: strings.homeChangeCategory,
+                  icon: Icons.grid_view_rounded,
+                  variant: AppButtonVariant.ghost,
+                  onPressed: () => context.go('/categories'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/state/category_selection.dart
+++ b/lib/ui/state/category_selection.dart
@@ -1,3 +1,113 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'dart:convert';
 
-final selectedCategoryProvider = StateProvider<String>((ref) => 'history');
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../theme/tokens.dart';
+import 'strings.dart';
+
+class CategoryDefinition {
+  const CategoryDefinition({
+    required this.id,
+    required this.titleKey,
+    required this.colorKey,
+    required this.iconKey,
+    required this.progress,
+    required this.locked,
+  });
+
+  factory CategoryDefinition.fromJson(Map<String, dynamic> json) {
+    return CategoryDefinition(
+      id: json['id'] as String,
+      titleKey: json['titleKey'] as String,
+      colorKey: json['colorKey'] as String,
+      iconKey: json['iconKey'] as String,
+      progress: (json['progress'] as num?)?.toDouble() ?? 0,
+      locked: json['locked'] as bool? ?? false,
+    );
+  }
+
+  final String id;
+  final String titleKey;
+  final String colorKey;
+  final String iconKey;
+  final double progress;
+  final bool locked;
+
+  Color get accentColor =>
+      AppColors.categoryColors[colorKey] ?? AppColors.primary;
+
+  IconData get iconData => _CategoryIconResolver.resolve(iconKey);
+
+  String localizedTitle(AppStrings strings) =>
+      strings.categoryTitle(titleKey);
+}
+
+final categoryListProvider = FutureProvider<List<CategoryDefinition>>((ref) async {
+  final bundle = rootBundle;
+  final raw = await bundle.loadString('assets/data/categories.json');
+  final data = jsonDecode(raw) as List<dynamic>;
+  return data
+      .map((item) => CategoryDefinition.fromJson(item as Map<String, dynamic>))
+      .toList(growable: false);
+});
+
+class SelectedCategoryController extends StateNotifier<String> {
+  SelectedCategoryController() : super('history') {
+    _hydrate();
+  }
+
+  static const String _storageKey = 'selected_category';
+  SharedPreferences? _preferences;
+
+  Future<void> _hydrate() async {
+    final prefs = await SharedPreferences.getInstance();
+    _preferences = prefs;
+    final stored = prefs.getString(_storageKey);
+    if (stored != null && stored.isNotEmpty) {
+      state = stored;
+    }
+  }
+
+  Future<void> select(String id) async {
+    state = id;
+    final prefs = _preferences ?? await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, id);
+  }
+}
+
+final selectedCategoryProvider =
+    StateNotifierProvider<SelectedCategoryController, String>(
+  (ref) => SelectedCategoryController(),
+);
+
+class _CategoryIconResolver {
+  static IconData resolve(String key) {
+    switch (key) {
+      case 'bank':
+        return Icons.account_balance_rounded;
+      case 'basketball':
+        return Icons.sports_basketball;
+      case 'movie':
+        return Icons.movie_creation_rounded;
+      case 'palette':
+        return Icons.palette_rounded;
+      case 'gamepad':
+        return Icons.sports_esports_rounded;
+      case 'book':
+        return Icons.menu_book_rounded;
+      case 'public':
+        return Icons.public_rounded;
+      case 'science':
+        return Icons.science_rounded;
+      case 'travel':
+        return Icons.flight_takeoff_rounded;
+      case 'music':
+        return Icons.music_note_rounded;
+      default:
+        return Icons.category_rounded;
+    }
+  }
+}

--- a/lib/ui/state/strings.dart
+++ b/lib/ui/state/strings.dart
@@ -11,15 +11,17 @@ class AppStrings {
     required this.resourcesEnergy,
     required this.resourcesGems,
     required this.resourcesLevel,
-    required this.homeHeadline,
-    required this.homeSubheading,
-    required this.homePrimaryAction,
-    required this.homeSecondaryAction,
+    required this.homeWeeklyTitle,
+    required this.homePlayWithFriends,
+    required this.homePlayButton,
+    required this.homeChangeCategory,
     required this.categoriesTitle,
+    required this.categoriesSubtitle,
+    required this.categoriesEmpty,
     required this.roundPlaceholderTitle,
     required this.roundPlaceholderSubtitle,
-    required this.weeklyBadge,
-    required this.modesBadge,
+    required this.categorySelectedLabel,
+    required this.categoryTitles,
   });
 
   final Locale locale;
@@ -28,15 +30,19 @@ class AppStrings {
   final String resourcesEnergy;
   final String resourcesGems;
   final String resourcesLevel;
-  final String homeHeadline;
-  final String homeSubheading;
-  final String homePrimaryAction;
-  final String homeSecondaryAction;
+  final String homeWeeklyTitle;
+  final String homePlayWithFriends;
+  final String homePlayButton;
+  final String homeChangeCategory;
   final String categoriesTitle;
+  final String categoriesSubtitle;
+  final String categoriesEmpty;
   final String roundPlaceholderTitle;
   final String roundPlaceholderSubtitle;
-  final String weeklyBadge;
-  final String modesBadge;
+  final String categorySelectedLabel;
+  final Map<String, String> categoryTitles;
+
+  String categoryTitle(String key) => categoryTitles[key] ?? key;
 
   static final Map<String, AppStrings> _lookup = <String, AppStrings>{
     'en': AppStrings(
@@ -46,15 +52,30 @@ class AppStrings {
       resourcesEnergy: 'Energy',
       resourcesGems: 'Gems',
       resourcesLevel: 'Level',
-      homeHeadline: 'Master the world of knowledge',
-      homeSubheading: 'Select a category, choose a mode, and rise through the ranks.',
-      homePrimaryAction: 'Start round',
-      homeSecondaryAction: 'Browse categories',
-      categoriesTitle: 'Pick your realm',
+      homeWeeklyTitle: 'Weekly challenge',
+      homePlayWithFriends: 'Play with friends',
+      homePlayButton: 'Play',
+      homeChangeCategory: 'Change category',
+      categoriesTitle: 'Categories',
+      categoriesSubtitle: 'Pick your arena and keep the streak alive.',
+      categoriesEmpty: 'Categories are not available right now.',
       roundPlaceholderTitle: 'Round in progress',
-      roundPlaceholderSubtitle: 'Gameplay arrives in the next milestone. For now enjoy the premium shell.',
-      weeklyBadge: 'Weekly',
-      modesBadge: 'Modes',
+      roundPlaceholderSubtitle:
+          'Gameplay arrives in the next milestone. For now enjoy the premium shell.',
+      categorySelectedLabel: 'Selected',
+      categoryTitles: const <String, String>{
+        'cat_history': 'History',
+        'cat_sport': 'Sport',
+        'cat_movies': 'Movies',
+        'cat_art': 'Art',
+        'cat_games': 'Games',
+        'cat_books': 'Books',
+        'cat_world': 'World',
+        'cat_tech': 'Technology',
+        'cat_food': 'Cuisine',
+        'cat_culture': 'Culture',
+        'cat_fashion': 'Fashion',
+      },
     ),
     'ru': AppStrings(
       locale: const Locale('ru'),
@@ -63,15 +84,30 @@ class AppStrings {
       resourcesEnergy: 'Энергия',
       resourcesGems: 'Кристаллы',
       resourcesLevel: 'Уровень',
-      homeHeadline: 'Покоряй мир знаний',
-      homeSubheading: 'Выбери категорию, настрой режим и продвигайся по лигам.',
-      homePrimaryAction: 'Начать раунд',
-      homeSecondaryAction: 'Категории',
-      categoriesTitle: 'Выбери мир',
+      homeWeeklyTitle: 'Еженедельный вызов',
+      homePlayWithFriends: 'Играть с друзьями',
+      homePlayButton: 'Играть',
+      homeChangeCategory: 'Сменить категорию',
+      categoriesTitle: 'Категории',
+      categoriesSubtitle: 'Выбери свою арену и держи серию.',
+      categoriesEmpty: 'Категории недоступны.',
       roundPlaceholderTitle: 'Раунд в разработке',
-      roundPlaceholderSubtitle: 'Игровая логика появится позже. Сейчас — премиальный каркас.',
-      weeklyBadge: 'Неделя',
-      modesBadge: 'Режимы',
+      roundPlaceholderSubtitle:
+          'Игровая логика появится позже. Сейчас — премиальный каркас.',
+      categorySelectedLabel: 'Выбрано',
+      categoryTitles: const <String, String>{
+        'cat_history': 'История',
+        'cat_sport': 'Спорт',
+        'cat_movies': 'Кино',
+        'cat_art': 'Искусство',
+        'cat_games': 'Игры',
+        'cat_books': 'Книги',
+        'cat_world': 'Мир',
+        'cat_tech': 'Технологии',
+        'cat_food': 'Кухня',
+        'cat_culture': 'Культура',
+        'cat_fashion': 'Мода',
+      },
     ),
   };
 


### PR DESCRIPTION
## Summary
- load category definitions from assets and persist the selected category in shared preferences
- redesign the home screen with gradient hero text, animated challenge cards, and a pulsing play call-to-action
- build a categories browser with gradient cards, progress bars, and hook up stub and round routes

## Testing
- Not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68da8fc7b3088326b3bd33cee7801e4f